### PR TITLE
feature: add citations to plot toolbar

### DIFF
--- a/src/components/data-rods/data-rods.component.ts
+++ b/src/components/data-rods/data-rods.component.ts
@@ -122,6 +122,7 @@ export default class TerraDataRods extends TerraElement {
                 end-date=${this.endDate}
                 location=${this.location}
                 bearer-token=${this.bearerToken}
+                show-citation=${true}
                 @terra-date-range-change=${this.#handleTimeSeriesDateRangeChange}
             ></terra-time-series>
 

--- a/src/components/plot-toolbar/plot-toolbar.component.ts
+++ b/src/components/plot-toolbar/plot-toolbar.component.ts
@@ -21,6 +21,8 @@ import { AuthController } from '../../auth/auth.controller.js'
 import { getTimeAveragedMapNotebook } from './notebooks/time-averaged-map-notebook.js'
 import { getTimeSeriesNotebook } from './notebooks/time-series-notebook.js'
 import { nothing } from 'lit'
+import { PlotToolbarController } from './plot-toolbar.controller.js'
+import { formatDate } from '../../utilities/date.js'
 
 /**
  * @summary Short summary of the component's intended use.
@@ -58,6 +60,13 @@ export default class TerraPlotToolbar extends TerraElement {
         true
     @property({ type: String }) colormap = 'viridis' // default colormap
     @property({ type: Number }) opacity = 1
+    @property({ type: Boolean, attribute: 'show-citation' }) showCitation: boolean =
+        false
+
+    /**
+     * if you include an application citation, it will be displayed in the citation panel alongside the dataset citation
+     */
+    @property({ attribute: 'application-citation' }) applicationCitation?: string
 
     @state()
     activeMenuItem: MenuNames = null
@@ -119,6 +128,7 @@ export default class TerraPlotToolbar extends TerraElement {
     @query('#menu') menu: HTMLMenuElement
 
     _authController = new AuthController(this)
+    #controller = new PlotToolbarController(this)
 
     @watch('activeMenuItem')
     handleFocus(_oldValue: MenuNames, newValue: MenuNames) {
@@ -234,6 +244,33 @@ export default class TerraPlotToolbar extends TerraElement {
                               <terra-icon name="info" font-size="1em"></terra-icon>
                           </terra-button>
 
+                          ${this.showCitation
+                              ? html`
+                                    <terra-button
+                                        circle
+                                        outline
+                                        aria-expanded=${this.activeMenuItem ===
+                                        'citation'}
+                                        aria-controls="menu"
+                                        aria-haspopup="true"
+                                        class="toggle"
+                                        @mouseenter=${this.#handleActiveMenuItem}
+                                        data-menu-name="citation"
+                                    >
+                                        <span class="sr-only"
+                                            >Citation for
+                                            ${this.catalogVariable
+                                                .dataFieldLongName}</span
+                                        >
+
+                                        <span
+                                            style="font-weight: 500; font-size: 1.2em"
+                                            >C</span
+                                        >
+                                    </terra-button>
+                                `
+                              : nothing}
+
                           <terra-button
                               circle
                               outline
@@ -334,6 +371,13 @@ export default class TerraPlotToolbar extends TerraElement {
                               ?hidden=${this.activeMenuItem !== 'information'}
                           >
                               ${this.#renderInfoPanel()}
+                          </li>
+
+                          <li
+                              role="menuitem"
+                              ?hidden=${this.activeMenuItem !== 'citation'}
+                          >
+                              ${this.#renderCitationPanel()}
                           </li>
 
                           <li
@@ -516,6 +560,47 @@ export default class TerraPlotToolbar extends TerraElement {
                     </a>
                 </dd>
             </dl>
+        `
+    }
+
+    #renderCitationPanel() {
+        const citation = this.#controller.collectionCitation?.collectionCitations[0]
+
+        if (!citation) {
+            return html`<div class="spacer"></div>`
+        }
+
+        return html`
+            <h3 class="sr-only">Citation</h3>
+
+            ${this.applicationCitation
+                ? html`
+                      <p>
+                          Please cite both the data used and the application itself.
+                      </p>
+                  `
+                : nothing}
+
+            <p>
+                <strong>Data Citation</strong>
+            </p>
+
+            <p>
+                ${citation?.creator} (${formatDate(citation?.releaseDate, 'yyyy')}),
+                ${citation?.title}, Edited by ${citation?.editor},
+                ${citation?.releasePlace}, ${citation?.publisher},
+                ${this.#controller.collectionCitation?.doi.doi}
+            </p>
+
+            ${this.applicationCitation
+                ? html`
+                      <p>
+                          <strong>Application Citation</strong>
+                      </p>
+
+                      <p>${this.applicationCitation}</p>
+                  `
+                : nothing}
         `
     }
 

--- a/src/components/plot-toolbar/plot-toolbar.controller.ts
+++ b/src/components/plot-toolbar/plot-toolbar.controller.ts
@@ -1,0 +1,41 @@
+import type {
+    CmrCollectionCitationItem,
+    MetadataCatalogInterface,
+} from '../../metadata-catalog/types.js'
+import type TerraPlotToolbar from './plot-toolbar.component.js'
+import { CmrCatalog } from '../../metadata-catalog/cmr-catalog.js'
+import { Task } from '@lit/task'
+import type { Variable } from '../browse-variables/browse-variables.types.js'
+import type { ReactiveControllerHost } from 'lit'
+
+export class PlotToolbarController {
+    #fetchCollectionTask: Task<[Variable], CmrCollectionCitationItem | undefined>
+
+    #host: ReactiveControllerHost & TerraPlotToolbar
+    #catalog: MetadataCatalogInterface
+
+    constructor(host: ReactiveControllerHost & TerraPlotToolbar) {
+        this.#host = host
+        this.#catalog = this.#getCatalogRepository()
+
+        this.#fetchCollectionTask = new Task(host, {
+            task: async ([catalogVariable], { signal }) => {
+                return this.#catalog.getCollectionCitation(
+                    `${catalogVariable.dataProductShortName}_${catalogVariable.dataProductVersion}`,
+                    {
+                        signal,
+                    }
+                )
+            },
+            args: (): [Variable] => [this.#host.catalogVariable],
+        })
+    }
+
+    get collectionCitation() {
+        return this.#fetchCollectionTask.value
+    }
+
+    #getCatalogRepository() {
+        return new CmrCatalog()
+    }
+}

--- a/src/components/plot-toolbar/plot-toolbar.types.ts
+++ b/src/components/plot-toolbar/plot-toolbar.types.ts
@@ -1,3 +1,10 @@
-export type MenuNames = 'download' | 'help' | 'information' | 'jupyter' | 'GeoTIFF' | null
+export type MenuNames =
+    | 'download'
+    | 'help'
+    | 'information'
+    | 'jupyter'
+    | 'GeoTIFF'
+    | 'citation'
+    | null
 
 export type DataType = 'csv' | 'geotiff' | null

--- a/src/components/time-series/time-series.component.ts
+++ b/src/components/time-series/time-series.component.ts
@@ -90,6 +90,14 @@ export default class TerraTimeSeries extends TerraElement {
     })
     location?: string
 
+    @property({ type: Boolean, attribute: 'show-citation' }) showCitation: boolean =
+        false
+
+    /**
+     * if you include an application citation, it will be displayed in the citation panel alongside the dataset citation
+     */
+    @property({ attribute: 'application-citation' }) applicationCitation?: string
+
     /**
      * The token to be used for authentication with remote servers.
      * The component provides the header "Authorization: Bearer" (the request header and authentication scheme).
@@ -217,6 +225,7 @@ export default class TerraTimeSeries extends TerraElement {
                               .endDate=${this.endDate}
                               .cacheKey=${this.#timeSeriesController.getCacheKey()}
                               .variableEntryId=${this.variableEntryId}
+                              .showCitation=${this.showCitation}
                           ></terra-plot-toolbar>`
                         : html`<div class="spacer"></div>`
                 )}

--- a/src/metadata-catalog/cmr-catalog.ts
+++ b/src/metadata-catalog/cmr-catalog.ts
@@ -1,5 +1,6 @@
 import { getGraphQLClient } from '../lib/graphql-client.js'
 import {
+    GET_CMR_COLLECTION_CITATIONS_BY_ENTRY_ID,
     GET_CMR_SEARCH_RESULTS_ALL,
     GET_CMR_SEARCH_RESULTS_COLLECTIONS,
     GET_CMR_SEARCH_RESULTS_VARIABLES,
@@ -9,6 +10,8 @@ import {
     type CmrSearchResult,
     type MetadataCatalogInterface,
     type SearchOptions,
+    type CmrCollectionCitationsResponse,
+    type CmrCollectionCitationItem,
 } from './types.js'
 
 export class CmrCatalog implements MetadataCatalogInterface {
@@ -66,5 +69,37 @@ export class CmrCatalog implements MetadataCatalogInterface {
             })) ?? []
 
         return [...collections, ...variables]
+    }
+
+    async getCollectionCitation(
+        collectionEntryId: string,
+        options?: SearchOptions
+    ): Promise<CmrCollectionCitationItem> {
+        const client = await getGraphQLClient('cmr')
+
+        const response = await client.query<CmrCollectionCitationsResponse>({
+            query: GET_CMR_COLLECTION_CITATIONS_BY_ENTRY_ID,
+            variables: {
+                entryId: collectionEntryId,
+            },
+            context: {
+                fetchOptions: {
+                    signal: options?.signal,
+                },
+            },
+            fetchPolicy: 'network-only',
+        })
+
+        if (
+            response.errors ||
+            response.data.collections.items.length === 0 ||
+            response.data.collections.items[0].collectionCitations.length === 0
+        ) {
+            throw new Error(
+                `Failed to retrieve collection citations from CMR: ${response.errors?.[0]?.message}`
+            )
+        }
+
+        return response.data.collections.items[0]
     }
 }

--- a/src/metadata-catalog/queries.ts
+++ b/src/metadata-catalog/queries.ts
@@ -1,5 +1,16 @@
 import { gql } from '@apollo/client/core'
 
+export const GET_CMR_COLLECTION_CITATIONS_BY_ENTRY_ID = gql`
+    query GetCMRCollectionByEntryId($entryId: String!) {
+        collections(params: { entryId: [$entryId] }) {
+            items {
+                doi
+                collectionCitations
+            }
+        }
+    }
+`
+
 export const GET_CMR_SEARCH_RESULTS_ALL = gql`
     query GetCMRSearchResultsAll($keyword: String!) {
         collections(params: { keyword: $keyword }) {

--- a/src/metadata-catalog/types.ts
+++ b/src/metadata-catalog/types.ts
@@ -7,11 +7,44 @@ export type SearchOptions = {
 }
 
 export interface MetadataCatalogInterface {
+    getCollectionCitation(
+        collectionEntryId: string,
+        options?: SearchOptions
+    ): Promise<CmrCollectionCitationItem>
+
     searchCmr(
         keyword: string,
         type: 'collection' | 'variable' | 'all',
         options?: SearchOptions
     ): Promise<Array<CmrSearchResult>>
+}
+
+export type CmrCollectionCitationsResponse = {
+    collections: {
+        items: Array<CmrCollectionCitationItem>
+    }
+}
+
+export type CmrCollectionCitationItem = {
+    doi: {
+        doi: string
+    }
+    collectionCitations: Array<CmrCollectionCitation>
+}
+
+export type CmrCollectionCitation = {
+    creator: string
+    editor: string
+    dataPresentationForm: string
+    onlineResource: {
+        linkage: string
+    }
+    publisher: string
+    title: string
+    seriesName: string
+    releaseDate: string
+    version: string
+    releasePlace: string
 }
 
 export type CmrSearchResult = {


### PR DESCRIPTION
Adds citations to the plot toolbar that shows up in time-series, data rods, etc. components.

<img width="1068" height="383" alt="Screenshot 2025-09-29 at 5 51 15 PM" src="https://github.com/user-attachments/assets/8b45b4c0-d629-4830-90c6-08f2c67b9a09" />

The citation itself is pulled from the CMR GraphQL API