### PR TITLE
GUUI:3574 update subsetter download python to use earth access

### DIFF
--- a/src/components/data-subsetter/assets/download_subset_files.py.txt
+++ b/src/components/data-subsetter/assets/download_subset_files.py.txt
@@ -2,28 +2,34 @@
 Python script for downloading data from a NASA Harmony job
 
 Requirements:
-    > pip install harmony
+    > pip install harmony-py
+    > pip install earthaccess
 
 To run the script: `python download_subset_files_{{jobId}}.py`
 
-You will be prompted for your Earthdata Login (https://urs.earthdata.nasa.gov) username and password.
+You will be prompted for your Earthdata Login (https://urs.earthdata.nasa.gov) or (https://urs.uat.earthdata.nasa.gov) username and password.
 
 If you would rather, you can store your EDL credentials in a .netrc file:
     > cd ~
     > touch .netrc
     > echo "machine urs.earthdata.nasa.gov login uid_goes_here password password_goes_here" > .netrc
+    > echo "machine urs.uat.earthdata.nasa.gov login uid_goes_here password password_goes_here" > .netrc
     > chmod 0600 .netrc
+
+
 """
 
 from harmony import Client
 from harmony.config import Environment
 import netrc
 from getpass import getpass
+import earthaccess
 
 
 def main(job_id="{{jobId}}"):
     login, password = get_login_credentials()
-    harmony_client = Client(auth=(login, password), env=Environment.PROD)
+    harmony_client = Client(auth=(login, password), env={{HARMONY_ENV}})
+    earthaccess.login(system={{EARTHACCESS_ENV}})
 
     print("Getting the subset job status from Harmony for job: ", job_id)
     job = harmony_client.status(job_id)
@@ -34,14 +40,12 @@ def main(job_id="{{jobId}}"):
         harmony_client.wait_for_processing(job_id, show_progress=True)
 
     # get a list of the jobs data urls
-    urls = harmony_client.result_urls(job_id)
+    urls = list(harmony_client.result_urls(job_id))
 
-    print("Downloading ", sum(1 for _ in urls), " files\n")
+    print("Downloading ", sum(1 for _ in urls), " files using earthaccess..\n")
+    earthaccess.download(urls,f"./{job_id}")
 
-    futures = harmony_client.download_all(job_id)
-    [f.result() for f in futures]
-
-    print("\nFinished downloading files!")
+    print(f"\nFinished downloading files! You can find them under the /{{jobId}} directory")
 
 
 def get_login_credentials():

--- a/src/components/data-subsetter/assets/download_subset_files.py.txt
+++ b/src/components/data-subsetter/assets/download_subset_files.py.txt
@@ -54,7 +54,12 @@ def get_login_credentials():
 
     try:
         nrc = netrc.netrc()
+        if({{HARMONY_ENV}}==Environment.Prod){
         login, _account, password = nrc.authenticators("urs.earthdata.nasa.gov")
+        }
+        else{
+             login, _account, password = nrc.authenticators("urs.uat.earthdata.nasa.gov")
+        }
     except Exception:
         login = None
         password = None

--- a/src/components/data-subsetter/data-subsetter.component.ts
+++ b/src/components/data-subsetter/data-subsetter.component.ts
@@ -1618,10 +1618,12 @@ export default class TerraDataSubsetter extends TerraElement {
             )
         }
 
-        const content = (await response.text()).replace(
-            /{{jobId}}/gi,
-            this.controller.currentJob!.jobID
-        )
+        const content = (await response.text())
+        .replace(/{{jobId}}/gi, this.controller.currentJob!.jobID)
+        .replace(/{{HARMONY_ENV}}/gi, `Environment.${this.environment?.toUpperCase()}`)
+        .replace(/{{EARTHACCESS_ENV}}/gi,`earthaccess.${this.environment?.toUpperCase()}`)
+
+
         const blob = new Blob([content], { type: 'text/plain' })
         const url = URL.createObjectURL(blob)
 


### PR DESCRIPTION
Instead of downloading the list of files using harmony-py, I am using earthaccess to download the list. By default 8 threads are used to download files in parallel. I have also modified the script to point to using UAT or PROD based on the environment you are in from the component