### PR TITLE
Make Notebook icon more prominent

### DIFF
--- a/src/components/plot-toolbar/plot-toolbar.component.ts
+++ b/src/components/plot-toolbar/plot-toolbar.component.ts
@@ -278,12 +278,12 @@ export default class TerraPlotToolbar extends TerraElement {
                           </terra-button>
 
                           <terra-button
-                              circle
                               outline
                               aria-expanded=${this.activeMenuItem === 'jupyter'}
                               aria-controls="menu"
                               aria-haspopup="true"
-                              class="toggle"
+                              class="toggle square-button"
+                              variant="warning"
                               @mouseenter=${this.#handleActiveMenuItem}
                               data-menu-name="jupyter"
                           >

--- a/src/components/plot-toolbar/plot-toolbar.styles.ts
+++ b/src/components/plot-toolbar/plot-toolbar.styles.ts
@@ -48,6 +48,12 @@ export default css`
         position: absolute;
     }
 
+    .square-button {
+        border-radius: 0 !important; /* square corners */
+        width: 2.5em;
+        height: 2.5em;
+    }
+
     menu {
         all: unset;
         position: absolute;


### PR DESCRIPTION
This PR contains changes for Jupyter notebook button more prominent then other information button with square shape and warning variant.