### PR TITLE
Feature/gu UI 3615 retrieve geotiff in jupyter notebook

### DIFF
--- a/docs/pages/components/time-average-map.md
+++ b/docs/pages/components/time-average-map.md
@@ -10,13 +10,23 @@ layout: component
 ### Render of geotiff data from time average map service.
 
 ```html:preview
-<terra-time-average-map
-    collection="M2T1NXAER_5_12_4"
-    variable="BCCMASS"
-    start-date="01/01/2009"
-    end-date="01/05/2009"
-    location="62,5,95,40"
-    bearer-token = "YOUR_BEARER_TOKEN"
+<terra-login style="width: 100%">
+    <span slot="loading">Loading...please wait</span>
 
-></terra-time-average-map>
+    <terra-time-average-map slot="logged-in"
+        collection="M2T1NXAER_5_12_4"
+        variable="BCCMASS"
+        start-date="01/01/2009"
+        end-date="01/05/2009"
+        location="62,5,95,40"
+    ></terra-time-average-map>
+
+    <p slot="logged-out">Please login to view this plot</p>
+</terra-login>
+
+<script>
+    document.querySelector('terra-time-average-map').addEventListener('terra-time-average-map-data-change', (e) => {
+        console.log('caught! ', e)
+    })
+</script>
 ```

--- a/src/components/plot-toolbar/notebooks/time-averaged-map-notebook.ts
+++ b/src/components/plot-toolbar/notebooks/time-averaged-map-notebook.ts
@@ -21,7 +21,7 @@ export function getTimeAveragedMapNotebook(host: TerraPlotToolbar) {
         {
             id: '2733501b-0de4-4067-8aff-864e1b4c76cb',
             cell_type: 'code',
-            source: '%pip install -q "terra_ui_components==0.0.111" "anywidget==0.9.15" "pandas"',
+            source: '%pip install -q "terra_ui_components==0.0.113" "anywidget==0.9.15" "pandas" "rasterio" "matplotlib"',
             metadata: {
                 trusted: true,
             },
@@ -49,9 +49,11 @@ export function getTimeAveragedMapNotebook(host: TerraPlotToolbar) {
             id: '25b87ed4-2ad9-4c7d-b851-bc8fea3ded5a',
             metadata: {},
             source: [
-                '### Access the map GeoTIFF data\n',
+                '### Access the map GeoTIFF bytes\n',
                 '\n',
-                'Once the map renders, you can access the data:',
+                'Once the map renders, you can access the GeoTIFF as bytes: `print(map.data)`',
+                '\n',
+                'Here is an example of loading the bytes into `rasterio` and plotting via `matplotlib`. Note: The bytes can be loaded into many other Python libraries:',
             ],
         },
         {
@@ -60,7 +62,7 @@ export function getTimeAveragedMapNotebook(host: TerraPlotToolbar) {
             id: '6b81a089-884d-4fd7-9d4e-c45a53307c20',
             metadata: {},
             outputs: [],
-            source: ['map.data'],
+            source: "import rasterio\nfrom rasterio.io import MemoryFile\nfrom io import BytesIO\nimport matplotlib.pyplot as plt\n\n# map.data contains the rendered GeoTIFF as bytes\nwith MemoryFile(map.data) as memfile:\n    with memfile.open() as dataset:\n        # You can now work with the dataset as if it were opened from a file\n        print(f\"Driver: {dataset.driver}\")\n        print(f\"CRS: {dataset.crs}\")\n        print(f\"Bounds: {dataset.bounds}\")\n        data = dataset.read(1)\n        print(f\"Data shape: {data.shape}\")\n\n        # Example of creating a figure and displaying the data\n        plt.figure(figsize=(10, 8))\n        plt.imshow(data, cmap='viridis')  # You can change the colormap\n        plt.colorbar(label='Values')\n        plt.title('GeoTIFF Visualization')\n        plt.xlabel('X')\n        plt.ylabel('Y')\n        plt.show()",
         },
     ]
 }

--- a/src/components/tab-panel/tab-panel.test.ts
+++ b/src/components/tab-panel/tab-panel.test.ts
@@ -1,10 +1,10 @@
-import '../../../dist/terra-ui-components.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import '../../../dist/terra-ui-components.js'
+import { expect, fixture, html } from '@open-wc/testing'
 
 describe('<terra-tab-panel>', () => {
     it('should render a component', async () => {
-        const el = await fixture(html` <terra-tab-panel></terra-tab-panel> `);
+        const el = await fixture(html` <terra-tab-panel></terra-tab-panel> `)
 
-        expect(el).to.exist;
-    });
-});
+        expect(el).to.exist
+    })
+})

--- a/src/components/tab-panel/tab-panel.ts
+++ b/src/components/tab-panel/tab-panel.ts
@@ -1,12 +1,12 @@
-import TerraTabPanel from './tab-panel.component.js';
+import TerraTabPanel from './tab-panel.component.js'
 
-export * from './tab-panel.component.js';
-export default TerraTabPanel;
+export * from './tab-panel.component.js'
+export default TerraTabPanel
 
-TerraTabPanel.define('terra-tab-panel');
+TerraTabPanel.define('terra-tab-panel')
 
 declare global {
     interface HTMLElementTagNameMap {
-      'terra-tab-panel': TerraTabPanel;
+        'terra-tab-panel': TerraTabPanel
     }
 }

--- a/src/components/tab/tab.test.ts
+++ b/src/components/tab/tab.test.ts
@@ -1,10 +1,10 @@
-import '../../../dist/terra-ui-components.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import '../../../dist/terra-ui-components.js'
+import { expect, fixture, html } from '@open-wc/testing'
 
 describe('<terra-tab>', () => {
     it('should render a component', async () => {
-        const el = await fixture(html` <terra-tab></terra-tab> `);
+        const el = await fixture(html` <terra-tab></terra-tab> `)
 
-        expect(el).to.exist;
-    });
-});
+        expect(el).to.exist
+    })
+})

--- a/src/components/tab/tab.ts
+++ b/src/components/tab/tab.ts
@@ -1,12 +1,12 @@
-import TerraTab from './tab.component.js';
+import TerraTab from './tab.component.js'
 
-export * from './tab.component.js';
-export default TerraTab;
+export * from './tab.component.js'
+export default TerraTab
 
-TerraTab.define('terra-tab');
+TerraTab.define('terra-tab')
 
 declare global {
     interface HTMLElementTagNameMap {
-      'terra-tab': TerraTab;
+        'terra-tab': TerraTab
     }
 }

--- a/src/components/tabs/tabs.component.ts
+++ b/src/components/tabs/tabs.component.ts
@@ -306,10 +306,9 @@ export default class TerraTabs extends TerraElement {
     private handleScrollToStart() {
         const isRtl = getComputedStyle(this).direction === 'rtl'
         this.nav.scroll({
-            left:
-                isRtl
-                    ? this.nav.scrollLeft + this.nav.clientWidth
-                    : this.nav.scrollLeft - this.nav.clientWidth,
+            left: isRtl
+                ? this.nav.scrollLeft + this.nav.clientWidth
+                : this.nav.scrollLeft - this.nav.clientWidth,
             behavior: 'smooth',
         })
     }
@@ -317,10 +316,9 @@ export default class TerraTabs extends TerraElement {
     private handleScrollToEnd() {
         const isRtl = getComputedStyle(this).direction === 'rtl'
         this.nav.scroll({
-            left:
-                isRtl
-                    ? this.nav.scrollLeft - this.nav.clientWidth
-                    : this.nav.scrollLeft + this.nav.clientWidth,
+            left: isRtl
+                ? this.nav.scrollLeft - this.nav.clientWidth
+                : this.nav.scrollLeft + this.nav.clientWidth,
             behavior: 'smooth',
         })
     }
@@ -359,10 +357,14 @@ export default class TerraTabs extends TerraElement {
             // Emit events
             if (options.emitEvents) {
                 if (previousTab) {
-                    this.emit('terra-tab-hide', { detail: { name: previousTab.panel } })
+                    this.emit('terra-tab-hide', {
+                        detail: { name: previousTab.panel },
+                    })
                 }
 
-                this.emit('terra-tab-show', { detail: { name: this.activeTab.panel } })
+                this.emit('terra-tab-show', {
+                    detail: { name: this.activeTab.panel },
+                })
             }
         }
     }
@@ -593,10 +595,7 @@ export default class TerraTabs extends TerraElement {
                           `
                         : ''}
 
-                    <div
-                        class="tabs__nav"
-                        @scrollend=${this.updateScrollButtons}
-                    >
+                    <div class="tabs__nav" @scrollend=${this.updateScrollButtons}>
                         <div part="tabs" class="tabs__tabs" role="tablist">
                             <div
                                 part="active-tab-indicator"

--- a/src/components/tabs/tabs.test.ts
+++ b/src/components/tabs/tabs.test.ts
@@ -1,10 +1,10 @@
-import '../../../dist/terra-ui-components.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import '../../../dist/terra-ui-components.js'
+import { expect, fixture, html } from '@open-wc/testing'
 
 describe('<terra-tabs>', () => {
     it('should render a component', async () => {
-        const el = await fixture(html` <terra-tabs></terra-tabs> `);
+        const el = await fixture(html` <terra-tabs></terra-tabs> `)
 
-        expect(el).to.exist;
-    });
-});
+        expect(el).to.exist
+    })
+})

--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -1,12 +1,12 @@
-import TerraTabs from './tabs.component.js';
+import TerraTabs from './tabs.component.js'
 
-export * from './tabs.component.js';
-export default TerraTabs;
+export * from './tabs.component.js'
+export default TerraTabs
 
-TerraTabs.define('terra-tabs');
+TerraTabs.define('terra-tabs')
 
 declare global {
     interface HTMLElementTagNameMap {
-      'terra-tabs': TerraTabs;
+        'terra-tabs': TerraTabs
     }
 }

--- a/src/events/terra-close.ts
+++ b/src/events/terra-close.ts
@@ -5,4 +5,3 @@ declare global {
         'terra-close': TerraCloseEvent
     }
 }
-

--- a/src/events/terra-tab-hide.ts
+++ b/src/events/terra-tab-hide.ts
@@ -5,4 +5,3 @@ declare global {
         'terra-tab-hide': TerraTabHideEvent
     }
 }
-

--- a/src/events/terra-tab-show.ts
+++ b/src/events/terra-tab-show.ts
@@ -5,4 +5,3 @@ declare global {
         'terra-tab-show': TerraTabShowEvent
     }
 }
-

--- a/src/terra-ui-components.ts
+++ b/src/terra-ui-components.ts
@@ -45,9 +45,9 @@ export { default as TerraSelect } from './components/select/select.js'
 export { default as TerraOption } from './components/option/option.js'
 export { default as TerraFileUpload } from './components/file-upload/file-upload.js'
 export { default as TerraTextarea } from './components/textarea/textarea.js'
-export { default as TerraTabs } from './components/tabs/tabs.js';
-export { default as TerraTab } from './components/tab/tab.js';
-export { default as TerraTabPanel } from './components/tab-panel/tab-panel.js';
+export { default as TerraTabs } from './components/tabs/tabs.js'
+export { default as TerraTab } from './components/tab/tab.js'
+export { default as TerraTabPanel } from './components/tab-panel/tab-panel.js'
 /* plop:component */
 
 // Utilities

--- a/src/terra_ui_components/time_average_map/time_average_map.py
+++ b/src/terra_ui_components/time_average_map/time_average_map.py
@@ -1,4 +1,5 @@
 import importlib.metadata
+import base64
 import traitlets
 from ..base import TerraBaseWidget
 
@@ -25,6 +26,7 @@ class TerraTimeAverageMap(TerraBaseWidget):
         component.startDate = model.get('startDate')
         component.endDate = model.get('endDate')
         component.location = model.get('location')
+        component.bearerToken = model.get('bearerToken')
         component.long_name = model.get('long_name')
 
         /**
@@ -56,6 +58,9 @@ class TerraTimeAverageMap(TerraBaseWidget):
         model.on('change:location', () => {
             component.location = model.get('location')
         })
+        model.on('change:bearerToken', () => {
+            component.bearerToken = model.get('bearerToken')
+        })
         model.on('change:long_name', () => {
             component.long_name = model.get('long_name')
         })
@@ -64,7 +69,7 @@ class TerraTimeAverageMap(TerraBaseWidget):
          * Add event listeners.
          * These are used to communicate back to the Jupyter notebook
          */
-        component.addEventListener('terra-time-average-map-data-change', (e) => {
+        component.addEventListener('terra-time-average-map-data-change', async (e) => {
             // hide the loading overlay, if it exists
             const loadingOverlay = document.getElementById('jupyterlite-loading-overlay')
 
@@ -72,9 +77,34 @@ class TerraTimeAverageMap(TerraBaseWidget):
                 loadingOverlay.remove()
             }
 
-            console.log('caught the event!! ', e)
+            console.log('time-average-map: finished mapping GeoTIFF. Sending GeoTIFF to Python... ', e)
 
-            model.set('data', e.detail.data.data)
+            // We can't send a JS Blob to Python, so we'll instead need to convert it to bytes
+            const blob = e.detail.data
+
+            if (blob instanceof Blob) {
+                const arrayBuffer = await blob.arrayBuffer()
+                const uint8Array = new Uint8Array(arrayBuffer)
+                
+                // Convert to base64 string for transmission to Python
+                // Use chunked conversion to avoid "Maximum call stack size exceeded" for large files
+                const chunkSize = 8192
+                let binaryString = ''
+                
+                for (let i = 0; i < uint8Array.length; i += chunkSize) {
+                    const chunk = uint8Array.subarray(i, i + chunkSize)
+                    binaryString += String.fromCharCode(...chunk)
+                }
+
+                const base64String = btoa(binaryString)
+                model.set('_data_base64', base64String)
+
+                console.log('time-average-map: sent base64 encoded GeoTIFF to Python ', base64String)
+            } else {
+                console.error('time-average-map: failed to send GeoTIFF to Python. Unknown data type', blob)
+                model.set('_data_base64', '')
+            }
+            
             model.save_changes()
         })
     }
@@ -90,6 +120,16 @@ class TerraTimeAverageMap(TerraBaseWidget):
     startDate = traitlets.Unicode('').tag(sync=True)
     endDate = traitlets.Unicode('').tag(sync=True)
     location = traitlets.Unicode('').tag(sync=True)
+    bearerToken = traitlets.Unicode('').tag(sync=True)
     long_name = traitlets.Unicode('').tag(sync=True)
-    data = traitlets.List(trait=traitlets.Dict(),
-                          default_value=[]).tag(sync=True)
+    _data_base64 = traitlets.Unicode('').tag(sync=True)
+
+    @property
+    def data(self):
+        """Get the binary data as bytes, decoded from base64."""
+        if not self._data_base64:
+            return b''
+        try:
+            return base64.b64decode(self._data_base64)
+        except Exception:
+            return b''

--- a/src/themes/horizon.css
+++ b/src/themes/horizon.css
@@ -692,7 +692,8 @@
 
     /* Tab padding */
     --terra-tab-padding-large: var(--terra-spacing-small) var(--terra-spacing-medium);
-    --terra-tab-padding-small: var(--terra-spacing-2x-small) var(--terra-spacing-small);
+    --terra-tab-padding-small: var(--terra-spacing-2x-small)
+        var(--terra-spacing-small);
     --terra-tab-padding-closable: var(--terra-spacing-2x-small);
 
     /* Tab close button */


### PR DESCRIPTION
Adds the ability to read the GeoTIFF produced from the time-average-map component into a Jupyter Notebook.
Shows an example of rendering the GeoTIFF using matplotlib

You can see it by going to the time-average-map docs, after map rendering, clicking "Open in Jupyter Notebook" and then running the last cell once the map is rendered

Some screenshots of the rendered Jupyter Notebook:

<img width="1194" height="597" alt="Screenshot 2025-11-22 at 9 59 59 AM" src="https://github.com/user-attachments/assets/e75b7f4d-3fb2-4edc-8d31-ae7338542439" />
<img width="820" height="816" alt="Screenshot 2025-11-22 at 10 00 06 AM" src="https://github.com/user-attachments/assets/b0fd1ab7-8520-45a1-9a7e-edeae26f12e4" />
