### PR TITLE
feat: add terra-colormap-picker component

### DIFF
--- a/docs/pages/components/colormap-picker.md
+++ b/docs/pages/components/colormap-picker.md
@@ -1,0 +1,82 @@
+---
+meta:
+    title: Colormap Picker
+    description: A colormap picker for selecting scientific data color scales.
+layout: component
+---
+
+```html:preview
+<terra-colormap-picker value="viridis" id="main-picker"></terra-colormap-picker>
+<p style="margin-top: 0.5rem;">Selected: <code id="main-output">viridis</code></p>
+
+<script>
+  const picker = document.getElementById('main-picker');
+  const output = document.getElementById('main-output');
+  picker.addEventListener('terra-colormap-change', e => {
+    output.textContent = e.detail.value;
+  });
+</script>
+```
+
+```jsx:react
+import { useState } from 'react';
+import TerraColormapPicker from '@nasa-terra/components/dist/react/colormap-picker';
+
+const App = () => {
+  const [value, setValue] = useState('viridis');
+  return (
+    <>
+      <TerraColormapPicker value={value} onTerraColormapChange={e => setValue(e.detail.value)} />
+      <p>Selected: <code>{value}</code></p>
+    </>
+  );
+};
+```
+
+## Examples
+
+### Disabled
+
+Add the `disabled` attribute to prevent interaction.
+
+```html:preview
+<terra-colormap-picker value="plasma" disabled></terra-colormap-picker>
+```
+
+### Setting Value Programmatically
+
+Set the `value` property in JavaScript to update the selection.
+
+```html:preview
+<terra-colormap-picker value="viridis" id="picker-prog"></terra-colormap-picker>
+<div style="margin-top: 0.75rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
+  <terra-button id="btn-viridis">viridis</terra-button>
+  <terra-button id="btn-plasma">plasma</terra-button>
+  <terra-button id="btn-rdbu">RdBu</terra-button>
+  <terra-button id="btn-tab10">tab10</terra-button>
+</div>
+
+<script>
+  const picker = document.getElementById('picker-prog');
+  document.getElementById('btn-viridis').addEventListener('click', () => picker.value = 'viridis');
+  document.getElementById('btn-plasma').addEventListener('click', () => picker.value = 'plasma');
+  document.getElementById('btn-rdbu').addEventListener('click', () => picker.value = 'RdBu');
+  document.getElementById('btn-tab10').addEventListener('click', () => picker.value = 'tab10');
+</script>
+```
+
+## Usage
+
+Use the filter buttons to narrow the list to **Sequential**, **Diverging**, or **Qualitative** colormaps:
+
+- **Sequential** — ordered data with a natural progression (temperature, elevation, reflectance)
+- **Diverging** — deviation from a midpoint (anomalies, differences from a baseline)
+- **Qualitative** — categorical data with no inherent order (land cover classes, sensor types)
+
+Listen for `terra-colormap-change` to get the selected name. The event detail contains `{ value: string }`.
+
+## Accessibility
+
+- Swatch grid uses `role="listbox"` with each swatch as `role="option"` and `aria-selected`.
+- Filter bar uses `role="tablist"` with `role="tab"` on each button.
+- All interactive elements support keyboard navigation and `Enter` / `Space` to select.

--- a/src/components/colormap-picker/colormap-picker.component.ts
+++ b/src/components/colormap-picker/colormap-picker.component.ts
@@ -1,0 +1,264 @@
+import { classMap } from 'lit/directives/class-map.js'
+import { html } from 'lit'
+import { property, state } from 'lit/decorators.js'
+import componentStyles from '../../styles/component.styles.js'
+import TerraElement from '../../internal/terra-element.js'
+import styles from './colormap-picker.styles.js'
+import type { CSSResultGroup } from 'lit'
+import type { ColormapCategory, ColormapEntry } from './colormap-picker.types.js'
+
+export { type ColormapCategory, type ColormapEntry }
+
+const COLORMAPS: ColormapEntry[] = [
+    // Sequential
+    {
+        name: 'viridis',
+        category: 'sequential',
+        gradient: 'linear-gradient(to right, #440154, #31688e, #35b779, #fde725)',
+    },
+    {
+        name: 'plasma',
+        category: 'sequential',
+        gradient: 'linear-gradient(to right, #0d0887, #7e03a8, #cc4778, #f89540, #f0f921)',
+    },
+    {
+        name: 'inferno',
+        category: 'sequential',
+        gradient: 'linear-gradient(to right, #000004, #420a68, #932667, #dd513a, #fca50a, #fcffa4)',
+    },
+    {
+        name: 'magma',
+        category: 'sequential',
+        gradient: 'linear-gradient(to right, #000004, #3b0f70, #8c2981, #de4968, #fe9f6d, #fcfdbf)',
+    },
+    {
+        name: 'cividis',
+        category: 'sequential',
+        gradient: 'linear-gradient(to right, #00204c, #31446b, #666870, #9b9b74, #d5c253, #ffea46)',
+    },
+    {
+        name: 'blues',
+        category: 'sequential',
+        gradient: 'linear-gradient(to right, #f7fbff, #c6dbef, #6baed6, #2171b5, #08306b)',
+    },
+    {
+        name: 'greens',
+        category: 'sequential',
+        gradient: 'linear-gradient(to right, #f7fcf5, #c7e9c0, #74c476, #238b45, #00441b)',
+    },
+    {
+        name: 'reds',
+        category: 'sequential',
+        gradient: 'linear-gradient(to right, #fff5f0, #fcbba1, #fb6a4a, #cb181d, #67000d)',
+    },
+    {
+        name: 'oranges',
+        category: 'sequential',
+        gradient: 'linear-gradient(to right, #fff5eb, #fdd0a2, #fd8d3c, #d94701, #7f2704)',
+    },
+    {
+        name: 'YlOrRd',
+        category: 'sequential',
+        gradient: 'linear-gradient(to right, #ffffcc, #fed976, #fd8d3c, #f03b20, #bd0026)',
+    },
+    {
+        name: 'YlGnBu',
+        category: 'sequential',
+        gradient: 'linear-gradient(to right, #ffffd9, #c7e9b4, #41b6c4, #1d91c0, #225ea8, #0c2c84)',
+    },
+    {
+        name: 'hot',
+        category: 'sequential',
+        gradient: 'linear-gradient(to right, #000000, #ff0000, #ffff00, #ffffff)',
+    },
+    // Diverging
+    {
+        name: 'RdBu',
+        category: 'diverging',
+        gradient: 'linear-gradient(to right, #67001f, #d6604d, #f7f7f7, #4393c3, #053061)',
+    },
+    {
+        name: 'RdYlBu',
+        category: 'diverging',
+        gradient: 'linear-gradient(to right, #d73027, #fdae61, #ffffbf, #74add1, #4575b4)',
+    },
+    {
+        name: 'coolwarm',
+        category: 'diverging',
+        gradient: 'linear-gradient(to right, #3b4cc0, #6b87d0, #f7f7f7, #dd8b63, #b40426)',
+    },
+    {
+        name: 'Spectral',
+        category: 'diverging',
+        gradient: 'linear-gradient(to right, #9e0142, #f46d43, #ffffbf, #66c2a5, #3288bd, #5e4fa2)',
+    },
+    {
+        name: 'BrBG',
+        category: 'diverging',
+        gradient: 'linear-gradient(to right, #543005, #bf812d, #f6e8c3, #c7eae5, #35978f, #003c30)',
+    },
+    {
+        name: 'PiYG',
+        category: 'diverging',
+        gradient: 'linear-gradient(to right, #8e0152, #de77ae, #f7f7f7, #7fbc41, #276419)',
+    },
+    {
+        name: 'PRGn',
+        category: 'diverging',
+        gradient: 'linear-gradient(to right, #40004b, #9970ab, #f7f7f7, #5aae61, #00441b)',
+    },
+    {
+        name: 'seismic',
+        category: 'diverging',
+        gradient: 'linear-gradient(to right, #00004d, #0000ff, #ffffff, #ff0000, #800000)',
+    },
+    // Qualitative
+    {
+        name: 'tab10',
+        category: 'qualitative',
+        gradient:
+            'linear-gradient(to right, #1f77b4 10%, #ff7f0e 10% 20%, #2ca02c 20% 30%, #d62728 30% 40%, #9467bd 40% 50%, #8c564b 50% 60%, #e377c2 60% 70%, #7f7f7f 70% 80%, #bcbd22 80% 90%, #17becf 90%)',
+    },
+    {
+        name: 'Set1',
+        category: 'qualitative',
+        gradient:
+            'linear-gradient(to right, #e41a1c 12.5%, #377eb8 12.5% 25%, #4daf4a 25% 37.5%, #984ea3 37.5% 50%, #ff7f00 50% 62.5%, #a65628 62.5% 75%, #f781bf 75% 87.5%, #999999 87.5%)',
+    },
+    {
+        name: 'Set2',
+        category: 'qualitative',
+        gradient:
+            'linear-gradient(to right, #66c2a5 12.5%, #fc8d62 12.5% 25%, #8da0cb 25% 37.5%, #e78ac3 37.5% 50%, #a6d854 50% 62.5%, #ffd92f 62.5% 75%, #e5c494 75% 87.5%, #b3b3b3 87.5%)',
+    },
+    {
+        name: 'Pastel1',
+        category: 'qualitative',
+        gradient:
+            'linear-gradient(to right, #fbb4ae 12.5%, #b3cde3 12.5% 25%, #ccebc5 25% 37.5%, #decbe4 37.5% 50%, #fed9a6 50% 62.5%, #ffffcc 62.5% 75%, #e5d8bd 75% 87.5%, #fddaec 87.5%)',
+    },
+]
+
+const CATEGORIES: { value: ColormapCategory; label: string }[] = [
+    { value: 'all', label: 'All' },
+    { value: 'sequential', label: 'Sequential' },
+    { value: 'diverging', label: 'Diverging' },
+    { value: 'qualitative', label: 'Qualitative' },
+]
+
+/**
+ * @summary A colormap picker for selecting scientific data color scales.
+ * @documentation https://terra-ui.netlify.app/components/colormap-picker
+ * @status stable
+ * @since 0.0.189
+ *
+ * @event terra-colormap-change - Emitted when the selected colormap changes. The event detail contains `{ value: string }`.
+ *
+ * @csspart base - The component's base wrapper.
+ * @csspart filter - The category filter bar.
+ * @csspart filter-button - An individual category filter button.
+ * @csspart grid - The colormap swatch grid.
+ * @csspart swatch - An individual colormap swatch.
+ * @csspart swatch-gradient - The gradient strip inside a swatch.
+ * @csspart swatch-label - The colormap name label inside a swatch.
+ */
+export default class TerraColormapPicker extends TerraElement {
+    static styles: CSSResultGroup = [componentStyles, styles]
+
+    /** The currently selected colormap name. */
+    @property({ reflect: true }) value: string = 'viridis'
+
+    /** Filters the displayed colormaps by category. */
+    @property({ reflect: true }) category: ColormapCategory = 'all'
+
+    /** Disables the picker. */
+    @property({ type: Boolean, reflect: true }) disabled = false
+
+    @state() private _filter: ColormapCategory = 'all'
+
+    #select(name: string) {
+        if (this.disabled || name === this.value) return
+        this.value = name
+        this.emit('terra-colormap-change', { detail: { value: name } })
+    }
+
+    #renderFilterBar() {
+        return html`
+            <div part="filter" class="colormap-picker__filter" role="tablist" aria-label="Filter colormaps by category">
+                ${CATEGORIES.map(
+                    ({ value, label }) => html`
+                        <button
+                            part="filter-button"
+                            role="tab"
+                            class=${classMap({
+                                'colormap-picker__filter-btn': true,
+                                'colormap-picker__filter-btn--active': this._filter === value,
+                            })}
+                            aria-selected=${this._filter === value}
+                            ?disabled=${this.disabled}
+                            @click=${() => { this._filter = value }}
+                        >
+                            ${label}
+                        </button>
+                    `
+                )}
+            </div>
+        `
+    }
+
+    #renderGrid() {
+        const visible = COLORMAPS.filter(
+            (cm) => this._filter === 'all' || cm.category === this._filter
+        )
+
+        return html`
+            <div part="grid" class="colormap-picker__grid" role="listbox" aria-label="Colormap options">
+                ${visible.map(
+                    (cm) => html`
+                        <button
+                            part="swatch"
+                            role="option"
+                            class=${classMap({
+                                'colormap-picker__swatch': true,
+                                'colormap-picker__swatch--selected': this.value === cm.name,
+                            })}
+                            aria-selected=${this.value === cm.name}
+                            aria-label=${cm.name}
+                            title=${cm.name}
+                            ?disabled=${this.disabled}
+                            @click=${() => this.#select(cm.name)}
+                            @keydown=${(e: KeyboardEvent) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                    e.preventDefault()
+                                    this.#select(cm.name)
+                                }
+                            }}
+                        >
+                            <span
+                                part="swatch-gradient"
+                                class="colormap-picker__swatch-gradient"
+                                style="background: ${cm.gradient}"
+                            ></span>
+                            <span part="swatch-label" class="colormap-picker__swatch-label">${cm.name}</span>
+                        </button>
+                    `
+                )}
+            </div>
+        `
+    }
+
+    render() {
+        return html`
+            <div
+                part="base"
+                class=${classMap({
+                    'colormap-picker': true,
+                    'colormap-picker--disabled': this.disabled,
+                })}
+            >
+                ${this.#renderFilterBar()}
+                ${this.#renderGrid()}
+            </div>
+        `
+    }
+}

--- a/src/components/colormap-picker/colormap-picker.styles.ts
+++ b/src/components/colormap-picker/colormap-picker.styles.ts
@@ -1,0 +1,120 @@
+import { css } from 'lit'
+
+export default css`
+    :host {
+        display: block;
+    }
+
+    :host([disabled]) {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+
+    .colormap-picker {
+        display: flex;
+        flex-direction: column;
+        gap: var(--terra-spacing-small);
+    }
+
+    /* Filter bar */
+
+    .colormap-picker__filter {
+        display: flex;
+        gap: var(--terra-spacing-x-small);
+        flex-wrap: wrap;
+    }
+
+    .colormap-picker__filter-btn {
+        padding: var(--terra-spacing-x-small) var(--terra-spacing-small);
+        border: 1px solid var(--terra-color-carbon-30);
+        border-radius: var(--terra-border-radius-medium);
+        background: transparent;
+        color: var(--terra-color-carbon-80);
+        font-size: var(--terra-font-size-small);
+        font-family: inherit;
+        cursor: pointer;
+        transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+        white-space: nowrap;
+    }
+
+    .colormap-picker__filter-btn:hover:not(:disabled) {
+        background-color: var(--terra-color-carbon-10);
+        border-color: var(--terra-color-carbon-50);
+    }
+
+    .colormap-picker__filter-btn--active {
+        background-color: var(--terra-color-nasa-blue);
+        border-color: var(--terra-color-nasa-blue);
+        color: var(--terra-color-spacesuit-white);
+    }
+
+    .colormap-picker__filter-btn--active:hover:not(:disabled) {
+        background-color: var(--terra-color-nasa-blue);
+        border-color: var(--terra-color-nasa-blue);
+    }
+
+    .colormap-picker__filter-btn:focus-visible {
+        outline: 2px solid var(--terra-color-nasa-blue);
+        outline-offset: 2px;
+    }
+
+    .colormap-picker__filter-btn:disabled {
+        cursor: not-allowed;
+    }
+
+    /* Swatch grid */
+
+    .colormap-picker__grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+        gap: var(--terra-spacing-x-small);
+    }
+
+    .colormap-picker__swatch {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        padding: var(--terra-spacing-x-small);
+        border: 2px solid transparent;
+        border-radius: var(--terra-border-radius-medium);
+        background: var(--terra-color-carbon-5, #f8f8f8);
+        cursor: pointer;
+        text-align: left;
+        transition: border-color 120ms ease, background-color 120ms ease;
+    }
+
+    .colormap-picker__swatch:hover:not(:disabled) {
+        background-color: var(--terra-color-carbon-10);
+        border-color: var(--terra-color-carbon-30);
+    }
+
+    .colormap-picker__swatch--selected {
+        border-color: var(--terra-color-nasa-blue);
+        background-color: var(--terra-color-carbon-10);
+    }
+
+    .colormap-picker__swatch:focus-visible {
+        outline: 2px solid var(--terra-color-nasa-blue);
+        outline-offset: 2px;
+    }
+
+    .colormap-picker__swatch:disabled {
+        cursor: not-allowed;
+    }
+
+    .colormap-picker__swatch-gradient {
+        display: block;
+        height: 18px;
+        border-radius: var(--terra-border-radius-small);
+        width: 100%;
+    }
+
+    .colormap-picker__swatch-label {
+        font-size: var(--terra-font-size-x-small);
+        color: var(--terra-color-carbon-70);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-family: var(--terra-font-mono, monospace);
+    }
+`

--- a/src/components/colormap-picker/colormap-picker.test.ts
+++ b/src/components/colormap-picker/colormap-picker.test.ts
@@ -1,0 +1,183 @@
+import { expect, fixture, html } from '@open-wc/testing'
+import './colormap-picker.js'
+
+describe('<terra-colormap-picker>', () => {
+    describe('Basic Rendering', () => {
+        it('should render the component', async () => {
+            const el = await fixture(html`<terra-colormap-picker></terra-colormap-picker>`)
+            expect(el).to.exist
+        })
+
+        it('should render a filter bar', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker></terra-colormap-picker>`)
+            const filter = el.shadowRoot?.querySelector('[part~="filter"]')
+            expect(filter).to.exist
+        })
+
+        it('should render a swatch grid', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker></terra-colormap-picker>`)
+            const grid = el.shadowRoot?.querySelector('[part~="grid"]')
+            expect(grid).to.exist
+        })
+
+        it('should render swatches', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker></terra-colormap-picker>`)
+            const swatches = el.shadowRoot?.querySelectorAll('[part~="swatch"]')
+            expect(swatches?.length).to.be.greaterThan(0)
+        })
+    })
+
+    describe('Default State', () => {
+        it('should default value to viridis', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker></terra-colormap-picker>`)
+            expect(el.value).to.equal('viridis')
+        })
+
+        it('should default category to all', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker></terra-colormap-picker>`)
+            expect(el.category).to.equal('all')
+        })
+
+        it('should default disabled to false', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker></terra-colormap-picker>`)
+            expect(el.disabled).to.be.false
+        })
+    })
+
+    describe('Properties', () => {
+        it('should accept a value property', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker value="plasma"></terra-colormap-picker>`)
+            expect(el.value).to.equal('plasma')
+        })
+
+        it('should reflect value as an attribute', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker value="inferno"></terra-colormap-picker>`)
+            expect(el.getAttribute('value')).to.equal('inferno')
+        })
+
+        it('should accept disabled property', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker disabled></terra-colormap-picker>`)
+            expect(el.disabled).to.be.true
+        })
+
+        it('should reflect disabled as an attribute', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker disabled></terra-colormap-picker>`)
+            expect(el.hasAttribute('disabled')).to.be.true
+        })
+    })
+
+    describe('Selected Swatch', () => {
+        it('should mark the selected swatch', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker value="plasma"></terra-colormap-picker>`)
+            const selected = el.shadowRoot?.querySelector('[part~="swatch"][aria-selected="true"]')
+            expect(selected).to.exist
+            expect(selected?.getAttribute('aria-label')).to.equal('plasma')
+        })
+
+        it('should apply selected class to the active swatch', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker value="viridis"></terra-colormap-picker>`)
+            const swatches = el.shadowRoot?.querySelectorAll('[part~="swatch"]')
+            const selected = Array.from(swatches ?? []).find((s: any) =>
+                s.getAttribute('aria-label') === 'viridis'
+            ) as HTMLElement | undefined
+            expect(selected?.classList.contains('colormap-picker__swatch--selected')).to.be.true
+        })
+    })
+
+    describe('Events', () => {
+        it('should emit terra-colormap-change when a swatch is clicked', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker value="viridis"></terra-colormap-picker>`)
+            let event: CustomEvent | null = null
+            el.addEventListener('terra-colormap-change', (e: CustomEvent) => { event = e })
+
+            const swatch = Array.from(
+                el.shadowRoot?.querySelectorAll('[part~="swatch"]') ?? []
+            ).find((s: any) => s.getAttribute('aria-label') === 'plasma') as HTMLElement | undefined
+
+            swatch?.click()
+            expect(event).to.exist
+            expect((event as any)?.detail?.value).to.equal('plasma')
+        })
+
+        it('should not emit terra-colormap-change when clicking the already-selected swatch', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker value="viridis"></terra-colormap-picker>`)
+            let count = 0
+            el.addEventListener('terra-colormap-change', () => { count++ })
+
+            const swatch = Array.from(
+                el.shadowRoot?.querySelectorAll('[part~="swatch"]') ?? []
+            ).find((s: any) => s.getAttribute('aria-label') === 'viridis') as HTMLElement | undefined
+
+            swatch?.click()
+            expect(count).to.equal(0)
+        })
+
+        it('should not emit terra-colormap-change when disabled', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker value="viridis" disabled></terra-colormap-picker>`)
+            let count = 0
+            el.addEventListener('terra-colormap-change', () => { count++ })
+
+            const swatch = Array.from(
+                el.shadowRoot?.querySelectorAll('[part~="swatch"]') ?? []
+            ).find((s: any) => s.getAttribute('aria-label') === 'plasma') as HTMLElement | undefined
+
+            swatch?.click()
+            expect(count).to.equal(0)
+        })
+    })
+
+    describe('Category Filtering', () => {
+        it('should render all colormaps by default', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker></terra-colormap-picker>`)
+            const swatches = el.shadowRoot?.querySelectorAll('[part~="swatch"]')
+            expect(swatches?.length).to.be.greaterThan(10)
+        })
+
+        it('should filter to sequential colormaps', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker></terra-colormap-picker>`)
+            const allSwatches = el.shadowRoot?.querySelectorAll('[part~="swatch"]')?.length ?? 0
+
+            const seqBtn = Array.from(
+                el.shadowRoot?.querySelectorAll('[part~="filter-button"]') ?? []
+            ).find((b: any) => b.textContent?.trim() === 'Sequential') as HTMLElement | undefined
+
+            seqBtn?.click()
+            await el.updateComplete
+
+            const filtered = el.shadowRoot?.querySelectorAll('[part~="swatch"]')?.length ?? 0
+            expect(filtered).to.be.lessThan(allSwatches)
+        })
+
+        it('should render four category filter buttons', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker></terra-colormap-picker>`)
+            const buttons = el.shadowRoot?.querySelectorAll('[part~="filter-button"]')
+            expect(buttons?.length).to.equal(4)
+        })
+    })
+
+    describe('Accessibility', () => {
+        it('should have a listbox role on the grid', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker></terra-colormap-picker>`)
+            const grid = el.shadowRoot?.querySelector('[part~="grid"]')
+            expect(grid?.getAttribute('role')).to.equal('listbox')
+        })
+
+        it('should have option role on each swatch', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker></terra-colormap-picker>`)
+            const swatch = el.shadowRoot?.querySelector('[part~="swatch"]')
+            expect(swatch?.getAttribute('role')).to.equal('option')
+        })
+
+        it('should have aria-label on each swatch matching the colormap name', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker></terra-colormap-picker>`)
+            const swatch = el.shadowRoot?.querySelector('[part~="swatch"]') as HTMLElement
+            expect(swatch?.getAttribute('aria-label')).to.be.a('string').and.not.empty
+        })
+
+        it('should have tablist role on the filter bar', async () => {
+            const el: any = await fixture(html`<terra-colormap-picker></terra-colormap-picker>`)
+            const filter = el.shadowRoot?.querySelector('[part~="filter"]')
+            expect(filter?.getAttribute('role')).to.equal('tablist')
+        })
+    })
+})

--- a/src/components/colormap-picker/colormap-picker.ts
+++ b/src/components/colormap-picker/colormap-picker.ts
@@ -1,0 +1,12 @@
+import TerraColormapPicker from './colormap-picker.component.js'
+
+export * from './colormap-picker.component.js'
+export default TerraColormapPicker
+
+TerraColormapPicker.define('terra-colormap-picker')
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'terra-colormap-picker': TerraColormapPicker
+    }
+}

--- a/src/components/colormap-picker/colormap-picker.types.ts
+++ b/src/components/colormap-picker/colormap-picker.types.ts
@@ -1,0 +1,7 @@
+export type ColormapCategory = 'all' | 'sequential' | 'diverging' | 'qualitative'
+
+export interface ColormapEntry {
+    name: string
+    category: Exclude<ColormapCategory, 'all'>
+    gradient: string
+}

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -59,3 +59,4 @@ export type { TerraDateSelectionInvalidEvent } from './terra-date-selection-inva
 export type { TerraHarmonyJobStatusUpdateEvent } from './terra-harmony-job-status-update.js'
 export type { TerraHarmonyJobSelectEvent } from './terra-harmony-job-select.js'
 export type { TerraHarmonyJobDeleteEvent } from './terra-harmony-job-delete.js'
+export type { TerraColormapChangeEvent } from './terra-colormap-change.js'

--- a/src/events/terra-colormap-change.ts
+++ b/src/events/terra-colormap-change.ts
@@ -1,0 +1,7 @@
+export type TerraColormapChangeEvent = CustomEvent<{ value: string }>
+
+declare global {
+    interface GlobalEventHandlersEventMap {
+        'terra-colormap-change': TerraColormapChangeEvent
+    }
+}

--- a/src/terra-ui-components.ts
+++ b/src/terra-ui-components.ts
@@ -63,6 +63,8 @@ export { default as TerraEarthdataLogin } from './components/earthdata-login/ear
 export { default as TerraHarmonyHistory } from './components/harmony-history/harmony-history.js'
 export { default as TerraBanner } from './components/banner/banner.js'
 
+export { default as TerraColormapPicker } from './components/colormap-picker/colormap-picker.js'
+
 /* plop:component */
 
 // Utilities


### PR DESCRIPTION
Adds a `terra-colormap-picker` web component for selecting scientific data color scales.

## What's included

- 23 colormaps across three categories (sequential, diverging, qualitative)
- Category filter bar to narrow the list
- `value`, `category`, and `disabled` properties; reflects to attributes
- Emits `terra-colormap-change` with `{ value: string }`
- Full keyboard navigation and ARIA roles (`listbox` / `option` / `tablist`)
- React wrapper via `@lit/react` and `TerraColormapChangeEvent` type export
- Docs page at `/components/colormap-picker`
- 23 tests passing across Chromium, Firefox, and WebKit

## Usage

```html
<terra-colormap-picker value="viridis"></terra-colormap-picker>
```

```js
picker.addEventListener('terra-colormap-change', e => console.log(e.detail.value))
```