### PR TITLE
removing the location reset in variable picker handling

### DIFF
--- a/src/components/data-rods/data-rods.component.ts
+++ b/src/components/data-rods/data-rods.component.ts
@@ -133,8 +133,6 @@ export default class TerraDataRods extends TerraElement {
     private compatibilityWarning() {
         this.spatialWarningMessage = undefined
 
-        console.log('checking compatibility, location is: ', this.location, ' and variable is: ', this.catalogVariable)
-
         if (!this.catalogVariable || !this.location) return
 
         const {

--- a/src/components/data-rods/data-rods.component.ts
+++ b/src/components/data-rods/data-rods.component.ts
@@ -133,6 +133,8 @@ export default class TerraDataRods extends TerraElement {
     private compatibilityWarning() {
         this.spatialWarningMessage = undefined
 
+        console.log('checking compatibility, location is: ', this.location, ' and variable is: ', this.catalogVariable)
+
         if (!this.catalogVariable || !this.location) return
 
         const {
@@ -265,7 +267,7 @@ export default class TerraDataRods extends TerraElement {
         }
 
         this.variableEntryId = newEntryId
-        this.location = undefined
+        /* this.location = undefined - not sure why this is here; shouldn't zero location because of variable change*/
         this.lastChanged = 'variable'
 
         this.compatibilityWarning()


### PR DESCRIPTION
# Overview
 
## What is the bug?

Setting location to undefined when a variable is selected causes the location to be set to a default bounding box...which invalidates the point time series request...and there is literally no communication to the user about this.  The simplest thing to do is NOT set location to undefined when selecting variables.  Not sure why this was done to begin with.  
 
## What is the solution?

Commented "this.location = undefined" in "handleVariableChange()"
 
Works in components page.