### PR TITLE
Feature/gu UI 3702 shape file subsetting

### DIFF
--- a/docs/pages/components/date-picker.md
+++ b/docs/pages/components/date-picker.md
@@ -218,8 +218,11 @@ Note: Presets are shown if any part of the preset range overlaps the `min-date`/
 <terra-date-picker
   id="preset-picker-with-time"
   range
+  split-inputs
   show-presets
   enable-time
+  timezone="America/New_York"
+  twelve-hour
 ></terra-date-picker>
 ```
 

--- a/docs/pages/components/date-picker.md
+++ b/docs/pages/components/date-picker.md
@@ -48,26 +48,28 @@ Use help text to display the desired date formatting, in case visitors choose to
 
 ## Properties
 
-| Property        | Attribute        | Type            | Default                               | Description                                                                                   |
-| --------------- | ---------------- | --------------- | ------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `id`            | `id`             | `string`        | -                                     | The unique identifier for the date picker                                                     |
-| `range`         | `range`          | `boolean`       | `false`                               | Enables date range picking (two calendars)                                                    |
-| `minDate`       | `min-date`       | `string`        | -                                     | Minimum selectable date (YYYY-MM-DD)                                                          |
-| `maxDate`       | `max-date`       | `string`        | -                                     | Maximum selectable date (YYYY-MM-DD)                                                          |
-| `startDate`     | `start-date`     | `string`        | -                                     | Initial start/single date (ISO or YYYY-MM-DD)                                                 |
-| `endDate`       | `end-date`       | `string`        | -                                     | Initial end date (range mode; ISO or YYYY-MM-DD)                                              |
-| `label`         | `label`          | `string`        | `"Select Date"`                       | Input label text                                                                              |
-| `helpText`      | `help-text`      | `string`        | `''`                                  | Help text displayed below the input (e.g., "Format: YYYY-MM-DD")                              |
-| `startLabel`    | `start-label`    | `string`        | -                                     | Custom label for the start date input (only used when `split-inputs` and `range` are true)    |
-| `endLabel`      | `end-label`      | `string`        | -                                     | Custom label for the end date input (only used when `split-inputs` and `range` are true)      |
-| `hideLabel`     | `hide-label`     | `boolean`       | `false`                               | Visually hide the label while keeping it accessible                                           |
-| `enableTime`    | `enable-time`    | `boolean`       | `false`                               | Enables time selection UI with 24-hour UTC format including hours, minutes, and seconds       |
-| `displayFormat` | `display-format` | `string`        | `YYYY-MM-DD` or `YYYY-MM-DD HH:mm:ss` | Display format for the input value                                                            |
-| `showPresets`   | `show-presets`   | `boolean`       | `false`                               | Shows a sidebar with preset ranges; shown if preset overlaps `min/max`. Hidden if none remain |
-| `presets`       | `presets`        | `PresetRange[]` | `[]` (auto-fill)                      | Custom preset ranges; when empty, a default set is provided                                   |
-| `inline`        | `inline`         | `boolean`       | `false`                               | Displays the calendar inline (always visible) instead of as a popover dropdown                |
-| `splitInputs`   | `split-inputs`   | `boolean`       | `false`                               | When `range` is true, displays two separate inputs side by side (one for start, one for end)  |
-| `showClose`     | `closable`       | `boolean`       | `false`                               | Optional close button to close date picker                                                    |
+| Property        | Attribute        | Type            | Default                               | Description                                                                                                |
+| --------------- | ---------------- | --------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `id`            | `id`             | `string`        | -                                     | The unique identifier for the date picker                                                                  |
+| `range`         | `range`          | `boolean`       | `false`                               | Enables date range picking (two calendars)                                                                 |
+| `minDate`       | `min-date`       | `string`        | -                                     | Minimum selectable date (YYYY-MM-DD)                                                                       |
+| `maxDate`       | `max-date`       | `string`        | -                                     | Maximum selectable date (YYYY-MM-DD)                                                                       |
+| `startDate`     | `start-date`     | `string`        | -                                     | Initial start/single date (ISO or YYYY-MM-DD)                                                              |
+| `endDate`       | `end-date`       | `string`        | -                                     | Initial end date (range mode; ISO or YYYY-MM-DD)                                                           |
+| `label`         | `label`          | `string`        | `"Select Date"`                       | Input label text                                                                                           |
+| `helpText`      | `help-text`      | `string`        | `''`                                  | Help text displayed below the input (e.g., "Format: YYYY-MM-DD")                                           |
+| `startLabel`    | `start-label`    | `string`        | -                                     | Custom label for the start date input (only used when `split-inputs` and `range` are true)                 |
+| `endLabel`      | `end-label`      | `string`        | -                                     | Custom label for the end date input (only used when `split-inputs` and `range` are true)                   |
+| `hideLabel`     | `hide-label`     | `boolean`       | `false`                               | Visually hide the label while keeping it accessible                                                        |
+| `enableTime`    | `enable-time`    | `boolean`       | `false`                               | Enables time selection UI with 24-hour UTC format including hours, minutes, and seconds                    |
+| `displayFormat` | `display-format` | `string`        | `YYYY-MM-DD` or `YYYY-MM-DD HH:mm:ss` | Display format for the input value                                                                         |
+| `showPresets`   | `show-presets`   | `boolean`       | `false`                               | Shows a sidebar with preset ranges; shown if preset overlaps `min/max`. Hidden if none remain              |
+| `presets`       | `presets`        | `PresetRange[]` | `[]` (auto-fill)                      | Custom preset ranges; when empty, a default set is provided                                                |
+| `inline`        | `inline`         | `boolean`       | `false`                               | Displays the calendar inline (always visible) instead of as a popover dropdown                             |
+| `splitInputs`   | `split-inputs`   | `boolean`       | `false`                               | When `range` is true, displays two separate inputs side by side (one for start, one for end)               |
+| `showClose`     | `closable`       | `boolean`       | `false`                               | Optional close button to close date picker                                                                 |
+| `timezone`      | `timezone`       | `string`        | -                                     | IANA timezone identifier (e.g., `America/New_York`). Affects time display only; emitted values remain UTC. |
+| `twelveHour`    | `twelve-hour`    | `boolean`       | `false`                               | Display time in 12-hour format with AM/PM toggle. Requires `enable-time`. Emitted values remain UTC 24h.   |
 ## Events
 
 The component emits:
@@ -125,6 +127,44 @@ The component emits:
   range
   enable-time
   split-inputs
+></terra-date-picker>
+```
+
+### Timezone Display
+
+When `timezone` is set to a valid IANA identifier, times are displayed in that timezone in the input and time picker. Emitted `terra-date-range-change` values remain UTC.
+
+```html:preview
+<terra-date-picker
+  id="timezone-picker"
+  enable-time
+  timezone="America/New_York"
+  start-date="2024-03-20T15:00:00Z"
+></terra-date-picker>
+```
+
+### 12-Hour Format
+
+When `twelve-hour` is set, the time picker displays hours in 12-hour format (1–12) with an AM/PM toggle button. Requires `enable-time`. Emitted values remain UTC 24-hour.
+
+```html:preview
+<terra-date-picker
+  id="twelve-hour-picker"
+  enable-time
+  twelve-hour
+  start-date="2024-03-20T15:00:00Z"
+></terra-date-picker>
+```
+
+### Timezone with 12-Hour Format
+
+```html:preview
+<terra-date-picker
+  id="tz-12h-picker"
+  enable-time
+  timezone="America/New_York"
+  twelve-hour
+  start-date="2024-03-20T15:00:00Z"
 ></terra-date-picker>
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-terra/components",
-  "version": "0.0.192",
+  "version": "0.0.193",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-terra/components",
-      "version": "0.0.192",
+      "version": "0.0.193",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@lit/task": "^1.0.0",
         "@tanstack/query-core": "^5.96.0",
         "@tanstack/query-persist-client-core": "^5.96.0",
+        "@turf/turf": "^7.3.5",
         "ag-grid-community": "^34.2.0",
         "colormap": "^2.3.2",
         "composed-offset-position": "^0.0.6",
@@ -3041,6 +3042,2133 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@turf/along": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-7.3.5.tgz",
+      "integrity": "sha512-Ee4AHV9j2Bnlm/5nm4ChY7nkwpaaMffSez9nsJ9HcMbzG+GgTkt0F5pn9d02U7YvuWqckM5lfr3kBI+w2uTz+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.5",
+        "@turf/destination": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/angle": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/angle/-/angle-7.3.5.tgz",
+      "integrity": "sha512-+c3UZfkL1nNacfpLkj89rRreIlKM5UALeeWpcw7hCEK4MycXCBmITkyLLXOzoQaRBc/7ua4PV0Ov13Y6Ck9PzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/rhumb-bearing": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/area": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-7.3.5.tgz",
+      "integrity": "sha512-sSn80wPT7XfBIDN3vurCPxhk9W4U8ozS/XImSqeLN8qveTICOxzZkhsGDMp0CuncaN+plWut4a2TdNM7mzZB6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.5.tgz",
+      "integrity": "sha512-oG1ya/HtBjAIg4TimbWx+nOYPbY0bCvt82Bq8tm6sBw3qqtbOyRSfDz79Sq90TnH7DXJprJ1qnVGKNtZ6jemfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox-clip": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-7.3.5.tgz",
+      "integrity": "sha512-FuADTCBfRwdzJb2gFawDGnD1jKlUOfsWcu5Uv8iyEgu9JLuLAIYtI/l9xVF76BAoAvSkLgMfUvrPQ4SXCSUrVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox-polygon": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-7.3.5.tgz",
+      "integrity": "sha512-Cs9Laej8zfSY51kORM9UcbY4Uf/7X3OIZr/LydbrmmARFSpYH/FZsEQjAGi1S1Q0aYbibVqjEUReHN3ZVsV5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bearing": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-7.3.5.tgz",
+      "integrity": "sha512-/qabIt/IuPsGlE6RukJ0zOirc6afNxoK7fK1WBNVnHuJjeOpSkW+7q1QW5XQGXBMv3odcD0ZgRR+MBiAHduYSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bezier-spline": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-7.3.5.tgz",
+      "integrity": "sha512-54qnreNRvV9BeTGz2YXJyma+m8HMusuXWw3AkG0bIJGtqJMHqFKC/rWOcYxVj1VM2ScoTgglFxvq7GtSna+KMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-clockwise": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-7.3.5.tgz",
+      "integrity": "sha512-VpDIpTKBjH4oPbzx1ns18TWcosi+qCRtgU1HIJHLj4NWyLNr7TX86DvomCvZRPfsFxkYYgkFlqHBG1a29dcyqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-concave": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-concave/-/boolean-concave-7.3.5.tgz",
+      "integrity": "sha512-CHrmnEww43CAwEPszrKtLjM13hWDmsFZe0eCocxOtXLMspj+LCheB0bjMfcoBYfoTsvOPXxnoLTK9n4xuWBRSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-7.3.5.tgz",
+      "integrity": "sha512-P4JUAHgvJkD+8ybQ6d1OHp9TBsGsjJxF5lWeXJgp0k4+Hd/D0CVy4/mhLkZdNa6QdljVdwNcfU0CTqy1WsSQig==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/boolean-point-on-line": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-split": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-crosses": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-7.3.5.tgz",
+      "integrity": "sha512-o4Gmb2gbPl4j7810ZrT9GZsGigY+HRwcOI9pkkKH6BJ4ewSlQCPzP4JFruZp0+mIXS6NnPv7+Lw3J8LN3kYw1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-equal": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@turf/polygon-to-line": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-disjoint": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-7.3.5.tgz",
+      "integrity": "sha512-Pz1GGUC6iL6xGVqhyo+fYg35kl4j/HONMEoC1voN3DcBOCcVlzq+ljvMpvE+oQiR7Q38xLhIxZneLCqMp5YrQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/polygon-to-line": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-equal": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-7.3.5.tgz",
+      "integrity": "sha512-xjSFi/BpxBY5tDDuSbixIRVq2AnDGcdLL8XOHzZtJWZjSa6tAi6afxSiMbQTGIhYfwwcB/sJcIUUffBaIQ2BiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clean-coords": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "geojson-equality-ts": "^1.0.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-intersects": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-intersects/-/boolean-intersects-7.3.5.tgz",
+      "integrity": "sha512-Z6GPYjozrmTuzWQD0x7o8RPm+4HC7hz9q23hdB3U1+Qahesv8Mtc+wo82tO4CG6/NRnJ9u79DlEhmR1DxUU4iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-disjoint": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-overlap": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-7.3.5.tgz",
+      "integrity": "sha512-DUeiPVqFSTjW79erPbo780pRcKCRad59NcscVsTYkZD/92peF/4rQvHbvAUpUDPZaQCxe+mvfeDHfUFmfVKCGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@turf/line-overlap": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "geojson-equality-ts": "^1.0.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-parallel": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-7.3.5.tgz",
+      "integrity": "sha512-+shvGYFUx1vPQRPNeKiJcHtLAf9fl3mzAl9tBx2z+dU0IZDKz76/MAaDYSrMya/BYilFZ0E4RCEVq1X3s+AfkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clean-coords": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/line-segment": "7.3.5",
+        "@turf/rhumb-bearing": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-in-polygon": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.5.tgz",
+      "integrity": "sha512-ba7+B0wzaS9GtERZOoXUZ6oW8IcIJHNQZf3c+tiD9ESjcsPO1Q/4qIJGTKl92nBLhhracHJxMWBM/U6hAVkaRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "point-in-polygon-hao": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-on-line": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-7.3.5.tgz",
+      "integrity": "sha512-TuWfrAT63W43BDzgYc94UzQ5/PjF1aTnh4AIzmQwez1YnimShYcOTwo8OIHzDaB6gbbvFsfxYMuOA5JOp942Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-touches": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-touches/-/boolean-touches-7.3.5.tgz",
+      "integrity": "sha512-GwD0gmbV1p+EFHojBjaa1cwGMybayOZUDLj562RlAAoexC8ownrW7W6oMAlM2VCxk4gq6CLx3hss9pONuQcKjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/boolean-point-on-line": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-valid": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-valid/-/boolean-valid-7.3.5.tgz",
+      "integrity": "sha512-ZezJCgFJS0JRJfj6fVSI1idcifTaWFW70NYRCUur9926DHLvSkfbtEF5i63yPQt2Zxx00FTUJPcHRzdgOiwECA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/boolean-crosses": "7.3.5",
+        "@turf/boolean-disjoint": "7.3.5",
+        "@turf/boolean-overlap": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/boolean-point-on-line": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "geojson-polygon-self-intersections": "^1.2.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-within": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-7.3.5.tgz",
+      "integrity": "sha512-FsZhkAoi9KU2F0D5dyOQ38A7y9Bk8XTmUfLKAJa12xHN0QtXZEYH86YdVlrI1XgfFB9gmUddJPFX+bJATy6rxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/boolean-point-on-line": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-split": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/buffer": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-7.3.5.tgz",
+      "integrity": "sha512-TGls3nYtWzviKHT00XVBfHKa7Z2oIZKqiHN7R0xErGwMSAR7YhxVROhxq/iyIsWZjl1SlPwweZZIxWILQuxpZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/center": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/jsts": "^2.7.1",
+        "@turf/meta": "7.3.5",
+        "@turf/projection": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "d3-geo": "1.7.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-7.3.5.tgz",
+      "integrity": "sha512-eub5/Kfdmn89ZqwCONHI7astmTDEtN5M6+JfOkgoSyhKKFhUJYNxUyH1F/vCtIP7j1K369Vs4L9TYiuGapvIKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-mean": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-7.3.5.tgz",
+      "integrity": "sha512-8IpS7zUZg0fuUpN9ViqT4gR6YMjSR1R1kHysaDxhP1zMrTJ84U5lGG+VQC7HpHqybOnuwkXZrV970h9Ni78n6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-median": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-7.3.5.tgz",
+      "integrity": "sha512-e+NeDKyZzIzSTA0qd9cwIuguCnDQSc6TLd1MjkHKTd37PCaPSc40TMEIBX1x+kJRwOxzmUgpubfHUG9zfjdtyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/center-mean": "7.3.5",
+        "@turf/centroid": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-of-mass": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-7.3.5.tgz",
+      "integrity": "sha512-eEzx4YKxUP55Apdjt7XXuQ906KKx4uSQWLxJw5OHE0rKOSN/qYTSdu0s7nQBAmGgAqeSC2538vuN7wEqMfYMvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/centroid": "7.3.5",
+        "@turf/convex": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.3.5.tgz",
+      "integrity": "sha512-hkWaqwGFdOn6Tf0EWfn2yn1XZ1FWE1h2C5ZWstDMu/FxYO5DB+YjlmOFPl4K6SmSOEgdV07eK2vDCyPeTHqKGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/circle": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-7.3.5.tgz",
+      "integrity": "sha512-Tse7GJrx0rxaQ5BdY6pHZ9HFPrZwRMry2yaqq94UsUyonhy1m7U2icB3Zp4M8o4XjHIGTCq9i2BYcGJram51Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/destination": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clean-coords": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-7.3.5.tgz",
+      "integrity": "sha512-e0ZTqVWiQaCI/b8EFb+HAS8lCDomWafAKxQuIv0IYks0GwOlVTDWTwsY2RX2685j2Y+QssqOsyHsPZCtAjc3YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-on-line": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clone": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.3.5.tgz",
+      "integrity": "sha512-qfIaHj3410QEcTpiCRnTzhq8YrUp2gWrUIPLBAEFykopNxJkq1du1VrRzvuAo36ap2UV7KppkS6wGNypbcxswQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-7.3.5.tgz",
+      "integrity": "sha512-ZYQSCxElarAaG4azNieZ0ylX1sietkHIVAZv6H5JfSz/EXbAekQIom/isoynfDl/jVyNonDT7UrDZdCIjKQ2Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters-dbscan": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-7.3.5.tgz",
+      "integrity": "sha512-xdc0ccv2fyiUSWrJYJFE6RTluf8oVCB0/aCOdUD/ZvtG3eyqGIXMRMzAR1PujQHjBWtI+ndD4Eq+DqiGukGK+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters-dbscan/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
+    },
+    "node_modules/@turf/clusters-dbscan/node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
+    "node_modules/@turf/clusters-kmeans": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-7.3.5.tgz",
+      "integrity": "sha512-MnKymdmL7vy4TR5CLkcNkNgsJP8ZBEiWkqnRYBJLq/hFoppTvXxKvkRzftWtLfkIWb5oQ2XMvBh8BgALN22d5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "skmeans": "0.9.7",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/collect": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-7.3.5.tgz",
+      "integrity": "sha512-ddcBDdnM2Rwjfedxsbjvb7Zhoqo6uCTcnaHvu3ej/g+Z9iJ/K2wkRWhEUVAg/wppso5io6qEPmmPpNlefePt+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/collect/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
+    },
+    "node_modules/@turf/collect/node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
+    "node_modules/@turf/combine": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-7.3.5.tgz",
+      "integrity": "sha512-olQH6WmLl3XAalbpiz7RSRr4/mogan38gvgDlo37ypW1ckeBUi+2TX5HgJUZq4wxa2gMlny72QYkqY9zW4Jw+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/concave": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-7.3.5.tgz",
+      "integrity": "sha512-T496U4K5mXsJXTKjnf7eW+4SYoDP0bXWhpcfpWuCAaDJy8n1Q8Dbslj7wqrWd2lqIhulVRF+3zWAh0bJS34L5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/tin": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "topojson-client": "3.x",
+        "topojson-server": "3.x",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/convex": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-7.3.5.tgz",
+      "integrity": "sha512-d/pq86he+/GB/2ObuBHapeT15QFsCPhhGab3uE4YjogLMbD8qtu0sRGF+cvvPRDNuCLycOBL/xgFLnf9SteYlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "concaveman": "^1.2.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/destination": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-7.3.5.tgz",
+      "integrity": "sha512-x6ylChhOlIbucRSw7wF6z2gSEqqQl+dE0nSH5AL/ojZkqqGYahiw+2P4A8ZMuDM6rzH+FIqRYDes0o4nSArZCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/difference": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-7.3.5.tgz",
+      "integrity": "sha512-iDyWYCvgS3vgB8W1ai2cvfJaTq9bOt1QghiVkCNIyccF97CgtYJzenREVVUlp8qU9lJlbQ/ameyKvXPA1uOAlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/directional-mean": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/directional-mean/-/directional-mean-7.3.5.tgz",
+      "integrity": "sha512-Fm3rVgX7xiCL8Ed68dZpUl5NEAgEpaUdkAaZLvhedfUmKcuXcfBwX8RebHwNWctxcvKVOhoAMSlogpV33JnKdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.5",
+        "@turf/centroid": "7.3.5",
+        "@turf/destination": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/length": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/dissolve": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-7.3.5.tgz",
+      "integrity": "sha512-6kZTc8rbGuBqxWW8iK1sJZC8r7vr5uWdv7nsMJ0eX8/g0mTKNgSGXo14hYqp2GN4bE7JzpAgpFeSX8Xu1psxlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/flatten": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.5.tgz",
+      "integrity": "sha512-uQAC63zg/l91KUxzfhqio7Ii3+UXTrPOVJScIdRj6EO6+9XHI4kC+AdyIS4cPAv14sZfJLIBxzMnzcGrss+kEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance-weight": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance-weight/-/distance-weight-7.3.5.tgz",
+      "integrity": "sha512-GpV2h5ZkbWMdUFe5BWm9lfeLFMnYR8CRj6HiguZBLesarSub6I0UNO1u8UhkRGi26YLGnFlBh7c4KyaakNx1Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/centroid": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/ellipse": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-7.3.5.tgz",
+      "integrity": "sha512-C478LrdvUkjwIVGN6PoYsFp27PuT+W2IH4ZOVt9sd4359hRPFhJ2m+f8jSPfS6rdamdvc/O+h7vNmOIBRP/TeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/destination": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/transform-rotate": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/envelope": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-7.3.5.tgz",
+      "integrity": "sha512-0Sc2AVx0JZ3MaQ0k6+khplU3wO7bwc1qAQ6Fd+Q4RhIVPY2JKstBdq5ftU1T/BHNf8KK+9y4qbSV2u8hnw/PqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/bbox-polygon": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/explode": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-7.3.5.tgz",
+      "integrity": "sha512-Qdd7ehX5AF0DdpJl+JJyxws7jEmsZBRV35wTm+Lyhapuc3yLHU7tN5EqJ+2lVV7RkUgBXEFQV+34pmPLPGQn+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/flatten": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-7.3.5.tgz",
+      "integrity": "sha512-4dDAyoY8wf4UCIJ2lH3JbypmEeqyuRFExHEPu6eJeaOybdpOV9kn3LqB0lsWArizFjJWQNS+0qpv08jD85jSPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/flip": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-7.3.5.tgz",
+      "integrity": "sha512-qDSBFqo5+8yE5gfBCsQZxgj0bGRx6abQg6TgYvg1wvYYHtUJL/0VS+QdDTmxZiYm8N46uNAv9pKvun9MGK+elA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/geojson-rbush": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/geojson-rbush/-/geojson-rbush-7.3.5.tgz",
+      "integrity": "sha512-30/hQqc+ErnlcavvDdxGfgm8VtsJDEzSYpf3mPqYxOyI976l49T6+1jCQD5xKswml6o8zZAaTSe6ZcSKF+SCNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/geojson-rbush/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
+    },
+    "node_modules/@turf/geojson-rbush/node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
+    "node_modules/@turf/great-circle": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-7.3.5.tgz",
+      "integrity": "sha512-VAio6hwPJIheSzrvsMkLDMHkCfHyOi4H4r1Y2ynb2oMiGiqZjkQ7jIFlRYBcTyO2RnwEOgwM/d3kwRImAwMVBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "arc": "^0.2.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/hex-grid": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-7.3.5.tgz",
+      "integrity": "sha512-sPtYXqbNvUxt8h4NzspcoFAVotd/75LgrLxxI84LGIVPCN+fsK1uWwr4a6MAlzfSbWbOYOq7OSWMSSXzHoQzJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/intersect": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/interpolate": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-7.3.5.tgz",
+      "integrity": "sha512-rl5LwK85etpvbSW1VEXp/I85kzgiGviXInrvvhQxzEF9xGKvs1ed/6dc1uy1LsczSr4wUnbdGATzZTF9lFYjIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/centroid": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/hex-grid": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/point-grid": "7.3.5",
+        "@turf/square-grid": "7.3.5",
+        "@turf/triangle-grid": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/intersect": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-7.3.5.tgz",
+      "integrity": "sha512-v11Do9ySbsE08ffiwboQeFKvYByyxzvAz0ls837A9T3rSC+8vKMmK815S+C5v8CBMLNhuBCSgqnOIV3zonNICQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/isobands": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-7.3.5.tgz",
+      "integrity": "sha512-WX6vpPkM8O8SY7hsijOtj4owVXP24nU33Q0eMhWdZ+YiDmAHgEOQcDhPJLvp0mIbyYj81mU73hdnilf3q9tk/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.5",
+        "@turf/bbox": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/explode": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/isolines": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-7.3.5.tgz",
+      "integrity": "sha512-n5QUX1/Z/PuPVpTUrKhYcKF95L5+nKF8hWznYtG/GsiMXfRqMeAEjTCqgKIgF8T65H4LrvcpLyq8VPQSi7aISw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/jsts": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@turf/jsts/-/jsts-2.7.2.tgz",
+      "integrity": "sha512-zAezGlwWHPyU0zxwcX2wQY3RkRpwuoBmhhNE9HY9kWhFDkCxZ3aWK5URKwa/SWKJbj9aztO+8vtdiBA28KVJFg==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "dependencies": {
+        "jsts": "2.7.1"
+      }
+    },
+    "node_modules/@turf/kinks": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-7.3.5.tgz",
+      "integrity": "sha512-dPW8d4vs1v8WMobjyq/TVqajjPwkMsl94IF58yp1UYlmJDQrW4iNRUmI9fFzww+fl7epCKNwY+jZhXf1DRi93w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/length": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-7.3.5.tgz",
+      "integrity": "sha512-Bi+vEP54wt1ly3BRcCOP0nd2kGTYEhGk6haQxTpkrqr3XtmqDh8c3NowSgseN2cegIZRjwCOEC8eSsZ0JemJdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-arc": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-7.3.5.tgz",
+      "integrity": "sha512-XrPicIoN7XCtiJ7e7ELje7GjMZrBw/nuJnz0mQoCwwHwmX8Oz9oRfb6uaiS8NeR4WBzUVdkmVR/ro0kW4lypog==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/circle": "7.3.5",
+        "@turf/destination": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-chunk": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-7.3.5.tgz",
+      "integrity": "sha512-z5/EBv79oyNXMYFpFIsA9gw/7TAKoJ9a/Ijo/jBeO47Fr1mV3JLtE3aB2i/nqLTYZWMU7K3Lnzwqt2Rn5Gri/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/length": "7.3.5",
+        "@turf/line-slice-along": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-intersect": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-7.3.5.tgz",
+      "integrity": "sha512-2Cl4oPsjaDdfIwz/5IRDdG2fNdfp3W6atICm81vnzl/GwURoVP+CLjXJ64QWWzpzIbgX2XprJQTmamByDt5MDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "sweepline-intersections": "^1.5.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-offset": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-7.3.5.tgz",
+      "integrity": "sha512-7tNI+4xKFOTQj720aJI7vuRMyTC+4hAqd7N8AnnZ0EpzH+sBfyrt8rNI/Vf3+d/iY0c9ZNbhU9Qhyb0ckJUdsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-overlap": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-7.3.5.tgz",
+      "integrity": "sha512-7lZMWYHuzM6EMlL5pIIi/Nh7GLsM7ilW8/jVyHP1yGfQ0c0YAUoJd/Xy3J2+9v8OkYiZW/t2LdwVoTmCEJLWxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-on-line": "7.3.5",
+        "@turf/geojson-rbush": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-segment": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/nearest-point-on-line": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "fast-deep-equal": "^3.1.3",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-segment": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-7.3.5.tgz",
+      "integrity": "sha512-TM1aCu7utM6fllAEHO8PNqBJZ/uoFJVNp2A0YI7FyWN928hPbacsvNtLeVz/Kq1ZbeqQ1ZIKRxo9FdVjaj8hGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-slice": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-7.3.5.tgz",
+      "integrity": "sha512-BGw5N4UvjH691J/z1P2S+hWBgCcvbl2/HXaqGvKTijXw5i1vzsZ9m07wLl/qH+i38OJDRMJ/+FkNZnrKpsoXLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/nearest-point-on-line": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-slice-along": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-7.3.5.tgz",
+      "integrity": "sha512-zLOU9mGFXJdbPvA3/zXpDsBmXY2paA7eD6/p0iYiP9OASYO0GDcarwY5K/E0uuEdLrMf8G8YA2cJDcEl9gRgFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.5",
+        "@turf/destination": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-split": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-7.3.5.tgz",
+      "integrity": "sha512-GEuy+LdbbaqtYjHk/i1G8sK51wfCdPqTO8uH0dJZ6WlcIcZQfRcKKI4ksFm7NkVyfmw8gXWbpMJD8lO380GFBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/geojson-rbush": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@turf/line-segment": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/nearest-point-on-line": "7.3.5",
+        "@turf/truncate": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-to-polygon": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-7.3.5.tgz",
+      "integrity": "sha512-PNWDN1B0nJRlgA4DAXeYEf53OZSWwsu/rtDB4wxe/1NwfM9zlDVElQ/mtgDPtZpwC2aDKV5+B0vTXfKR/MMIfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/mask": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-7.3.5.tgz",
+      "integrity": "sha512-zs9bBtdANOsSkG7xiLFYforeI2nszXu0QwPv3vkaX747oEVdcyd0nSW81aQRmSWw/fvhXja++8duIVXOIYr4ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/midpoint": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-7.3.5.tgz",
+      "integrity": "sha512-y92O2YDDBkZp7jAUuUPgof/HiXHjJSkKjEtQRjWXZcjTlzHd/Fqg6/twarY2wNkENK2EuaaiV9MDy74FeRG2Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.5",
+        "@turf/destination": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/moran-index": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/moran-index/-/moran-index-7.3.5.tgz",
+      "integrity": "sha512-l/FgZkgPzwAsdj7rtKYWv2rxeTy+Tv8NMk6qSEwKqB4eHqn1TYHcTASWRcZIyipH4LtOJJOl77n7FmKcaDBtSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance-weight": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-neighbor-analysis": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-neighbor-analysis/-/nearest-neighbor-analysis-7.3.5.tgz",
+      "integrity": "sha512-6vnSqt7OH8zTPdvUxCYnnN86Ci8VS5G3q2G1UrAcrnjTH7DbJ4KvIkRQlv4y6hj53G+bm9cA6TjeJuyP2jAOcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.5",
+        "@turf/bbox": "7.3.5",
+        "@turf/bbox-polygon": "7.3.5",
+        "@turf/centroid": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/nearest-point": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-7.3.5.tgz",
+      "integrity": "sha512-qcsbj9fo5CYhGeIDaJORoqiZyjNGu2+Te31MVaFoTTxqqkXypxp9e6HJGvUi2zPd1Zk3oAWXhvm1a+UXw2G56w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.3.5.tgz",
+      "integrity": "sha512-MZn6OkEFZpjS6BNUANfqiHMIbQSivu7TNji3a+OAIrnPJ71vp8cbz0N2aVEa5M7I8ipvxoxAPIV3eqg3h280Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-to-line": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-7.3.5.tgz",
+      "integrity": "sha512-O27A9dFAqDYBRPhhoLP82Da7Q6rd0fXRR/jwQcBiycjTGdsXJmzxywuR08aDvWiARbJAmohEzdYzk4f9/eWXhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/point-to-line-distance": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/planepoint": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-7.3.5.tgz",
+      "integrity": "sha512-+hjECX1hDbol8psuG6iYSwcZHQ+RPJqFIBh3pXKc/pa0cdjZyB/L6q1d8ahnFrQBEpuoO3XVvo2hHN49VOEPjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-grid": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-7.3.5.tgz",
+      "integrity": "sha512-aEPnqj/4C9ejNz4uCJKgk6Flux6SxnqxjQHAYPIP5C7ooAB1xRAT1NMnCzxUjjUq1SMtgdZ6skoNfvKNK4Rzrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-within": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-on-feature": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-7.3.5.tgz",
+      "integrity": "sha512-Y7W+JZJCmm9Qq93NHpk4dVhzAtAk2Uyau2Uk1ttCJ2Jsnuu4dwSjOurpmgDmMUe7yPmzihAUYhMFDumpAja8ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/center": "7.3.5",
+        "@turf/explode": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/nearest-point": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-7.3.5.tgz",
+      "integrity": "sha512-mR1NAIX+JfpYAJQ9u3gpIV37QzYvBOefDP+/16uBCAOM8Fp12goT8l7WdenT0dvB4wPibbqM2+2kyEl5u9XJog==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/nearest-point-on-line": "7.3.5",
+        "@turf/projection": "7.3.5",
+        "@turf/rhumb-bearing": "7.3.5",
+        "@turf/rhumb-distance": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-to-polygon-distance": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-polygon-distance/-/point-to-polygon-distance-7.3.5.tgz",
+      "integrity": "sha512-SQPhAlfiuCkIIFos/OPCxtt8iR3BlZqGKzKXLYqt6z8iaICaf2SjMyn4Zsr1oFO+Gy2K1rqandR+kuLTIo8Eqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/point-to-line-distance": "7.3.5",
+        "@turf/polygon-to-line": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/points-within-polygon": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-7.3.5.tgz",
+      "integrity": "sha512-TRyVY5Xlx6j72sNIyBaHZNgTbILs2iUDevX5lnCFTiThkzp25BIBBQ77tv2VPilYH+v7+9/0T/pLO37SaVhsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-smooth": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-smooth/-/polygon-smooth-7.3.5.tgz",
+      "integrity": "sha512-dc/dlYFqVBcel6d5HM5tBANh1HfWbJ89lSVLR7YhRX+Y/UABTvbtJCWwxBBiFxFBeRmW7B45nv3jytHUYxQUOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-tangents": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-7.3.5.tgz",
+      "integrity": "sha512-3/TtCQlXc2Lrgzb+LjwqbtILWan7lRD6P9Nn3edm2xGAZw5WY17+yZfpeySJPfcZhOWten9dXkOwDvSZF5uyWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/boolean-within": "7.3.5",
+        "@turf/explode": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/nearest-point": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-to-line": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-7.3.5.tgz",
+      "integrity": "sha512-Mat5tvJcW3grpXCNFcMvjHL3d8hO4eoIgF3qYpXj25BHx/S7SJUOgyCV5x3arC0rCfM/cB71VmNDm9k57ec7bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygonize": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-7.3.5.tgz",
+      "integrity": "sha512-pD3Zv/392sLlZVKRGUrJ4CKLN/Im+TO6wMCOfm/uiq4F9pEL5R+HPvXTcwEyxbhEPKYn3cylGKt21Wq0OfNQDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/envelope": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/projection": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-7.3.5.tgz",
+      "integrity": "sha512-G4bejYKT0vCQZryMhEoS9aLmP7ThDg6nb3zi3wPzELiTrGNOd2YgkWVheQDGCk4hcqEIWZc9fI2alaRSSkkLVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/quadrat-analysis": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/quadrat-analysis/-/quadrat-analysis-7.3.5.tgz",
+      "integrity": "sha512-e5Am3cJuiP43f89Xv7n9cv3Z4P0I17zBvQPvhj6UowpRbiYoD4TKHfOr2PWHLYUkXjQ+vKY5CwiWvCYbfj3BIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.5",
+        "@turf/bbox": "7.3.5",
+        "@turf/bbox-polygon": "7.3.5",
+        "@turf/centroid": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/point-grid": "7.3.5",
+        "@turf/random": "7.3.5",
+        "@turf/square-grid": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/random": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/random/-/random-7.3.5.tgz",
+      "integrity": "sha512-Fid43jfmQpvrpr/wrUaW9hr66ukPqfZPuwzEt3gfCx6mAVpFWbCPx2yRuVlLNiRkMgmKTphFfh6267UCPOSnCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rectangle-grid": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/rectangle-grid/-/rectangle-grid-7.3.5.tgz",
+      "integrity": "sha512-SVtXOJIz7FYaRUinxb0HfE/GNSJU6eU9tlKQaERDo/vG7wjPoTCDvnH8p4BdE5GRdXZMjvBUhtNdMj+M3rGRjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-intersects": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rewind": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-7.3.5.tgz",
+      "integrity": "sha512-4AZdDh55JeCoKWLS5AC6MuXqAvoqSpj2WigtowtA3JIJ/1J4SclRrV6BGq/Xemwm5yKtRePHazBVUmG5uU75og==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-clockwise": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-bearing": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-7.3.5.tgz",
+      "integrity": "sha512-pYjBAuQTND0+6Y+v+zlQ7Y68SGjP4iG8qJ5QKjFRbB/yeorTY3m9yiXIN4lSyno3TPzEgBeNULuo26H6ygDyng==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-destination": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-7.3.5.tgz",
+      "integrity": "sha512-znICdPBtZq5EKh/Qu0TkiMyNhqiYfM2VUlFOWa7iegCWe1E+X7q/f6rlZ5TcmYVyLZ95XZ6eciDNmgVmpHVWaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-distance": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-7.3.5.tgz",
+      "integrity": "sha512-dBFxmKrjRaAdwc4SCmGyAS2BDPCH35IBNl++Ypd1RB8JR2D3khl3zrTvxrlJ5qoN1WDvyPbvDYCrt2UnTX+8Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/sample": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-7.3.5.tgz",
+      "integrity": "sha512-ayl/QlDAkqIDJjbzcBeAsMzFmIDanQP4xXdNKZmnYg83FhvH/Sgu7mMNNhrYwCVMWrmOicviDHu3xKuJ6jVnMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/sector": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-7.3.5.tgz",
+      "integrity": "sha512-9mtBorGPZfbZI2MoI0nkN5ogmbCz/NLpHdEM0UwwWiOW430iPhwZ649DXH32lDGerfzREX10vpamX8v1P9YVrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/circle": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-arc": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/shortest-path": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-7.3.5.tgz",
+      "integrity": "sha512-RmrfdDVTuBsHDNr88tGMRmIdJNFTdna3nQWRF8yFsgKR9LhZ4MWqebL24eQFn2hkyclL7O6lyPpOEJJtQxvcDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/bbox-polygon": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/clean-coords": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/transform-scale": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/simplify": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-7.3.5.tgz",
+      "integrity": "sha512-9wzxlRA+0yNALeqyXNHFgj+8ebsg2aKdMrWRiSMS+ZqbiknZ/mCARiDYqM2Qz8TgTqdrNt53ze4o1vS6WeJrJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clean-coords": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/square": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/square/-/square-7.3.5.tgz",
+      "integrity": "sha512-zUh9cxlZ4bPkSK2XynY26JSLDVy8oUss94mXACqSGrGjv308q3Voj4dzvfeh0E/Q3PQ3D8GJRZECXdCB/PU78Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/square-grid": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-7.3.5.tgz",
+      "integrity": "sha512-mcwefBumsO3nwRG4nPfmXsq7YqHOsa71Z3h4JwWQn/XOrhV/8l1/QX3IAIx1qUWC2RqRMOImt3et5mlc+g2SxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/rectangle-grid": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/standard-deviational-ellipse": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-7.3.5.tgz",
+      "integrity": "sha512-CIJaQ61bjmxxqi5CpRLWAwxnbeHcG6e7esK2IX2DXBIE/7p/F7Sk9F2GOAL6vt1o29GnmzU2APHZvTX/YKcLbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/center-mean": "7.3.5",
+        "@turf/ellipse": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/points-within-polygon": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tag": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-7.3.5.tgz",
+      "integrity": "sha512-jwLOP7ZFfOcMPbK+0puT0SMOs0urSKYSYax7G4LDtZ9oPFAicVJtr2K0OB/rgmdoTK4VfUwb2nVZUdYAVnXtAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tesselate": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-7.3.5.tgz",
+      "integrity": "sha512-MI+pSkehJyZmbl2L5/43B9DlD6MEDcr63pW/LDSXYRDoRUXtSGY/NAAibIQ0gMAr8VxsimGCZKSuGMNUZdsuRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "earcut": "^2.2.4",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tesselate/node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "license": "ISC"
+    },
+    "node_modules/@turf/tin": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-7.3.5.tgz",
+      "integrity": "sha512-70747SmLQttt+ywq+NmMqmkHdXsinO57SjHNFKX6G6qHuvxUu48vN7Kf3zjkqGAp2kQnu38OOqB4QPus6RdUqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-rotate": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-7.3.5.tgz",
+      "integrity": "sha512-WXkteI0DihwCukZesVXVVYpsoyftYoiBtq1b+u1Dz4HyATK25zfEeWChlgRtApbiePF6uqG7bSQS+K8vjC4c0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/centroid": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/rhumb-bearing": "7.3.5",
+        "@turf/rhumb-destination": "7.3.5",
+        "@turf/rhumb-distance": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-scale": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-7.3.5.tgz",
+      "integrity": "sha512-eAmey/LtJVT6WlCMULsnd+sCAOwCezG6lVP67qN5HARZ8ft+b7yBiU4FC+IGXbVsrdRcCRLSzoQc6K0fROoo2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/center": "7.3.5",
+        "@turf/centroid": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/rhumb-bearing": "7.3.5",
+        "@turf/rhumb-destination": "7.3.5",
+        "@turf/rhumb-distance": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-translate": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-7.3.5.tgz",
+      "integrity": "sha512-OMQLOFLIjqeDNARaa2kdh1AgvWKFgq41/I6k3CAaj1UcB4javpVFMlcjRJY+pL2oZtMRZRcUZxhO+zSNl6p83Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/rhumb-destination": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/triangle-grid": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-7.3.5.tgz",
+      "integrity": "sha512-oiwtTm+yqZwuODOSEyLSQSFaZFyjC6kgftUFFW6kLGQtm+Fw1GjxwS7QjiY55GRWxgfgbg2l1iNZNgfsCiPQWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/intersect": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/truncate": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.3.5.tgz",
+      "integrity": "sha512-Qx2iv3KIqKuDAUduMfaJ5fFegEWBeRve5zePalRevS16bMUqEX+jnKPK9fWGyUuPqT61qP1Kybz0PTWPbUbljQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/turf": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-7.3.5.tgz",
+      "integrity": "sha512-l5Z1ZFEizN9p5GxX3mzUGf+i4t7AP3YpWcNdf9+kIzJcQD3eYuGBabj2hLrfrluqFJ+uxsuo4RgPtortQ9Dwpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/along": "7.3.5",
+        "@turf/angle": "7.3.5",
+        "@turf/area": "7.3.5",
+        "@turf/bbox": "7.3.5",
+        "@turf/bbox-clip": "7.3.5",
+        "@turf/bbox-polygon": "7.3.5",
+        "@turf/bearing": "7.3.5",
+        "@turf/bezier-spline": "7.3.5",
+        "@turf/boolean-clockwise": "7.3.5",
+        "@turf/boolean-concave": "7.3.5",
+        "@turf/boolean-contains": "7.3.5",
+        "@turf/boolean-crosses": "7.3.5",
+        "@turf/boolean-disjoint": "7.3.5",
+        "@turf/boolean-equal": "7.3.5",
+        "@turf/boolean-intersects": "7.3.5",
+        "@turf/boolean-overlap": "7.3.5",
+        "@turf/boolean-parallel": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/boolean-point-on-line": "7.3.5",
+        "@turf/boolean-touches": "7.3.5",
+        "@turf/boolean-valid": "7.3.5",
+        "@turf/boolean-within": "7.3.5",
+        "@turf/buffer": "7.3.5",
+        "@turf/center": "7.3.5",
+        "@turf/center-mean": "7.3.5",
+        "@turf/center-median": "7.3.5",
+        "@turf/center-of-mass": "7.3.5",
+        "@turf/centroid": "7.3.5",
+        "@turf/circle": "7.3.5",
+        "@turf/clean-coords": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/clusters": "7.3.5",
+        "@turf/clusters-dbscan": "7.3.5",
+        "@turf/clusters-kmeans": "7.3.5",
+        "@turf/collect": "7.3.5",
+        "@turf/combine": "7.3.5",
+        "@turf/concave": "7.3.5",
+        "@turf/convex": "7.3.5",
+        "@turf/destination": "7.3.5",
+        "@turf/difference": "7.3.5",
+        "@turf/directional-mean": "7.3.5",
+        "@turf/dissolve": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/distance-weight": "7.3.5",
+        "@turf/ellipse": "7.3.5",
+        "@turf/envelope": "7.3.5",
+        "@turf/explode": "7.3.5",
+        "@turf/flatten": "7.3.5",
+        "@turf/flip": "7.3.5",
+        "@turf/geojson-rbush": "7.3.5",
+        "@turf/great-circle": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/hex-grid": "7.3.5",
+        "@turf/interpolate": "7.3.5",
+        "@turf/intersect": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/isobands": "7.3.5",
+        "@turf/isolines": "7.3.5",
+        "@turf/kinks": "7.3.5",
+        "@turf/length": "7.3.5",
+        "@turf/line-arc": "7.3.5",
+        "@turf/line-chunk": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@turf/line-offset": "7.3.5",
+        "@turf/line-overlap": "7.3.5",
+        "@turf/line-segment": "7.3.5",
+        "@turf/line-slice": "7.3.5",
+        "@turf/line-slice-along": "7.3.5",
+        "@turf/line-split": "7.3.5",
+        "@turf/line-to-polygon": "7.3.5",
+        "@turf/mask": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/midpoint": "7.3.5",
+        "@turf/moran-index": "7.3.5",
+        "@turf/nearest-neighbor-analysis": "7.3.5",
+        "@turf/nearest-point": "7.3.5",
+        "@turf/nearest-point-on-line": "7.3.5",
+        "@turf/nearest-point-to-line": "7.3.5",
+        "@turf/planepoint": "7.3.5",
+        "@turf/point-grid": "7.3.5",
+        "@turf/point-on-feature": "7.3.5",
+        "@turf/point-to-line-distance": "7.3.5",
+        "@turf/point-to-polygon-distance": "7.3.5",
+        "@turf/points-within-polygon": "7.3.5",
+        "@turf/polygon-smooth": "7.3.5",
+        "@turf/polygon-tangents": "7.3.5",
+        "@turf/polygon-to-line": "7.3.5",
+        "@turf/polygonize": "7.3.5",
+        "@turf/projection": "7.3.5",
+        "@turf/quadrat-analysis": "7.3.5",
+        "@turf/random": "7.3.5",
+        "@turf/rectangle-grid": "7.3.5",
+        "@turf/rewind": "7.3.5",
+        "@turf/rhumb-bearing": "7.3.5",
+        "@turf/rhumb-destination": "7.3.5",
+        "@turf/rhumb-distance": "7.3.5",
+        "@turf/sample": "7.3.5",
+        "@turf/sector": "7.3.5",
+        "@turf/shortest-path": "7.3.5",
+        "@turf/simplify": "7.3.5",
+        "@turf/square": "7.3.5",
+        "@turf/square-grid": "7.3.5",
+        "@turf/standard-deviational-ellipse": "7.3.5",
+        "@turf/tag": "7.3.5",
+        "@turf/tesselate": "7.3.5",
+        "@turf/tin": "7.3.5",
+        "@turf/transform-rotate": "7.3.5",
+        "@turf/transform-scale": "7.3.5",
+        "@turf/transform-translate": "7.3.5",
+        "@turf/triangle-grid": "7.3.5",
+        "@turf/truncate": "7.3.5",
+        "@turf/union": "7.3.5",
+        "@turf/unkink-polygon": "7.3.5",
+        "@turf/voronoi": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "@types/kdbush": "^3.0.5",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/union": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-7.3.5.tgz",
+      "integrity": "sha512-/FSKhl+LX4+M7L/Trmiln0CDPWS8vCneGnQktt1o5XbCY/zIpH1JdxHEBFXhFZg4beAyXCz0uuxRyW9N/DH+KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/unkink-polygon": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-7.3.5.tgz",
+      "integrity": "sha512-7MwKCm7sPHVF4xBO/3s08/DtA/09UEBXaLNnm8/RUq3abS5zZ9PnakLsd36J18IHDscM6RmH7IZPLSwYh4TLcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/unkink-polygon/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
+    },
+    "node_modules/@turf/unkink-polygon/node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
+    "node_modules/@turf/voronoi": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-7.3.5.tgz",
+      "integrity": "sha512-v51D9H+er/K5lP+rBs7jIBEXTFhl0FQOZn4mfhb7brN5sGGDmnfEFOaxIYOiJN4Qco1GtFD2Tq0NgZ8+dmJmEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/d3-voronoi": "^1.1.12",
+        "@types/geojson": "^7946.0.10",
+        "d3-voronoi": "1.1.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@types/accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
@@ -3151,6 +5279,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-voronoi": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.12.tgz",
+      "integrity": "sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw==",
+      "license": "MIT"
+    },
     "node_modules/@types/debounce": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/debounce/-/debounce-1.2.4.tgz",
@@ -3195,6 +5329,12 @@
       "resolved": "https://registry.npmjs.org/@types/fined/-/fined-1.1.5.tgz",
       "integrity": "sha512-2N93vadEGDFhASTIRbizbl4bNqpMOId5zZfj6hHqYZfEzEfO9onnU4Im8xvzo8uudySDveDHBOOSlTWf38ErfQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/http-assert": {
@@ -3265,6 +5405,12 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/kdbush": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/kdbush/-/kdbush-3.0.5.tgz",
+      "integrity": "sha512-tdJz7jaWFu4nR+8b2B+CdPZ6811ighYylWsu2hpsivapzW058yP0KdfZuNY89IiRe5jbKvBGXN3LQdN2KPXVdQ==",
+      "license": "MIT"
     },
     "node_modules/@types/keygrip": {
       "version": "1.0.6",
@@ -4882,6 +7028,14 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/arc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/arc/-/arc-0.2.0.tgz",
+      "integrity": "sha512-8NFOo126uYKQJyXNSLY/jSklgfLQL+XWAcPXGo876JwEQ8nSOPXWNI3TV2jLZMN8QEw8uksJ1ZwS4npjBca8MA==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/archive-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-4.0.0.tgz",
@@ -5387,6 +7541,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -6793,6 +8956,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/concaveman": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.2.1.tgz",
+      "integrity": "sha512-PwZYKaM/ckQSa8peP5JpVr7IMJ4Nn/MHIaWUjP4be+KoZ7Botgs8seAZGpmaOM+UZXawcdYRao/px9ycrCihHw==",
+      "license": "ISC",
+      "dependencies": {
+        "point-in-polygon": "^1.1.0",
+        "rbush": "^3.0.1",
+        "robust-predicates": "^2.0.4",
+        "tinyqueue": "^2.0.3"
+      }
+    },
+    "node_modules/concaveman/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
+    },
+    "node_modules/concaveman/node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
     "node_modules/config-chain": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
@@ -7351,6 +9541,27 @@
       "resolved": "https://registry.npmjs.org/custom-elements-manifest/-/custom-elements-manifest-1.0.0.tgz",
       "integrity": "sha512-j59k0ExGCKA8T6Mzaq+7axc+KVHwpEphEERU7VZ99260npu/p/9kd+Db+I3cGKxHkM5y6q5gnlXn00mzRQkX2A==",
       "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-geo": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
+      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1"
+      }
+    },
+    "node_modules/d3-voronoi": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
+      "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/data-uri-to-buffer": {
@@ -9137,6 +11348,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-equals": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
@@ -9787,6 +12004,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/geojson-equality-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-equality-ts/-/geojson-equality-ts-1.0.2.tgz",
+      "integrity": "sha512-h3Ryq+0mCSN/7yLs0eDgrZhvc9af23o/QuC4aTiuuzP/MRCtd6mf5rLsLRY44jX0RPUfM8c4GqERQmlUxPGPoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.14"
+      }
+    },
+    "node_modules/geojson-polygon-self-intersections": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/geojson-polygon-self-intersections/-/geojson-polygon-self-intersections-1.2.2.tgz",
+      "integrity": "sha512-6XRNF4CsRHYmR9z5YuIk5f/aOototnDf0dgMqYGcS7y1l57ttt6MAIAxl3rXyas6lq1HEbTuLMh4PgvO+OV42w==",
+      "license": "MIT",
+      "dependencies": {
+        "rbush": "^2.0.1"
+      }
+    },
+    "node_modules/geojson-polygon-self-intersections/node_modules/quickselect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+      "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==",
+      "license": "ISC"
+    },
+    "node_modules/geojson-polygon-self-intersections/node_modules/rbush": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+      "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^1.0.1"
       }
     },
     "node_modules/geotiff": {
@@ -12469,6 +14719,15 @@
       "dependencies": {
         "is-promise": "^2.0.0",
         "promise": "^7.0.1"
+      }
+    },
+    "node_modules/jsts": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.7.1.tgz",
+      "integrity": "sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/junk": {
@@ -16783,6 +19042,37 @@
       "integrity": "sha512-sz2HLP8gkysLx/BanM2PtJTtZ1PLPwdHwMWNri2YxLBy3IOeuDsVQtlmWa4hoK3j/fi4naaD3uZJqH5ozM3zGg==",
       "license": "MIT"
     },
+    "node_modules/point-in-polygon": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
+      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==",
+      "license": "MIT"
+    },
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
+      "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/point-in-polygon-hao/node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
+    "node_modules/polyclip-ts": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/polyclip-ts/-/polyclip-ts-0.16.8.tgz",
+      "integrity": "sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.1.0",
+        "splaytree-ts": "^1.0.2"
+      }
+    },
     "node_modules/portfinder": {
       "version": "1.0.38",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
@@ -18207,6 +20497,12 @@
         "node": "*"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
+      "integrity": "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
@@ -19048,6 +21344,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/skmeans": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/skmeans/-/skmeans-0.9.7.tgz",
+      "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg==",
+      "license": "MIT"
+    },
     "node_modules/slash": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
@@ -19381,6 +21683,12 @@
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/splaytree-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
+      "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==",
+      "license": "BDS-3-Clause"
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -19831,6 +22139,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sweepline-intersections": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sweepline-intersections/-/sweepline-intersections-1.5.0.tgz",
+      "integrity": "sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyqueue": "^2.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -20081,6 +22398,12 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "license": "ISC"
+    },
     "node_modules/title-case": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/title-case/-/title-case-4.3.2.tgz",
@@ -20138,6 +22461,44 @@
       "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
       "integrity": "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/topojson-server": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.1.tgz",
+      "integrity": "sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "geo2topo": "bin/geo2topo"
+      }
+    },
+    "node_modules/topojson-server/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
     "node_modules/tough-cookie": {
@@ -20206,7 +22567,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsscmp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-terra/components",
-  "version": "0.0.193",
+  "version": "0.0.194",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-terra/components",
-      "version": "0.0.193",
+      "version": "0.0.194",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-terra/components",
-  "version": "0.0.191",
+  "version": "0.0.192",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-terra/components",
-      "version": "0.0.191",
+      "version": "0.0.192",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nasa-terra/components",
   "description": "A collection of NASA Earthdata components",
-  "version": "0.0.193",
+  "version": "0.0.194",
   "homepage": "https://github.com/nasa/terra-ui-components",
   "author": "NASA GES DISC <https://disc.gsfc.nasa.gov>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@lit/task": "^1.0.0",
     "@tanstack/query-core": "^5.96.0",
     "@tanstack/query-persist-client-core": "^5.96.0",
+    "@turf/turf": "^7.3.5",
     "ag-grid-community": "^34.2.0",
     "colormap": "^2.3.2",
     "composed-offset-position": "^0.0.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nasa-terra/components",
   "description": "A collection of NASA Earthdata components",
-  "version": "0.0.192",
+  "version": "0.0.193",
   "homepage": "https://github.com/nasa/terra-ui-components",
   "author": "NASA GES DISC <https://disc.gsfc.nasa.gov>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nasa-terra/components",
   "description": "A collection of NASA Earthdata components",
-  "version": "0.0.191",
+  "version": "0.0.192",
   "homepage": "https://github.com/nasa/terra-ui-components",
   "author": "NASA GES DISC <https://disc.gsfc.nasa.gov>",
   "license": "MIT",

--- a/packages/create-terra-ui-app/boilerplates/nextjs/framework.js
+++ b/packages/create-terra-ui-app/boilerplates/nextjs/framework.js
@@ -67,7 +67,7 @@ export async function create(nextTask, outputDir, boilerplatesDir, appName) {
             "import { setBasePath } from '@nasa-terra/components/dist/utilities/base-path.js'"
 
         // Create the setBasePath call with comments (with newline before it)
-        const setBasePathCall = `\n/**\n * Sets the base path to the Terra UI CDN\n *\n * If you'd rather host the assets locally, you should setup a build task to copy the assets locally and\n * set the base path to your local public folder\n * (see https://terra-ui.netlify.app/frameworks/react/#installation for more information)\n */\nsetBasePath('https://cdn.jsdelivr.net/npm/@nasa-terra/components@0.0.191/cdn/')`
+        const setBasePathCall = `\n/**\n * Sets the base path to the Terra UI CDN\n *\n * If you'd rather host the assets locally, you should setup a build task to copy the assets locally and\n * set the base path to your local public folder\n * (see https://terra-ui.netlify.app/frameworks/react/#installation for more information)\n */\nsetBasePath('https://cdn.jsdelivr.net/npm/@nasa-terra/components@0.0.192/cdn/')`
 
         // Reconstruct the file: CSS import at top, then existing content with setBasePath import and call inserted
         const newLines = [...lines]

--- a/packages/create-terra-ui-app/boilerplates/nextjs/framework.js
+++ b/packages/create-terra-ui-app/boilerplates/nextjs/framework.js
@@ -67,7 +67,7 @@ export async function create(nextTask, outputDir, boilerplatesDir, appName) {
             "import { setBasePath } from '@nasa-terra/components/dist/utilities/base-path.js'"
 
         // Create the setBasePath call with comments (with newline before it)
-        const setBasePathCall = `\n/**\n * Sets the base path to the Terra UI CDN\n *\n * If you'd rather host the assets locally, you should setup a build task to copy the assets locally and\n * set the base path to your local public folder\n * (see https://terra-ui.netlify.app/frameworks/react/#installation for more information)\n */\nsetBasePath('https://cdn.jsdelivr.net/npm/@nasa-terra/components@0.0.192/cdn/')`
+        const setBasePathCall = `\n/**\n * Sets the base path to the Terra UI CDN\n *\n * If you'd rather host the assets locally, you should setup a build task to copy the assets locally and\n * set the base path to your local public folder\n * (see https://terra-ui.netlify.app/frameworks/react/#installation for more information)\n */\nsetBasePath('https://cdn.jsdelivr.net/npm/@nasa-terra/components@0.0.193/cdn/')`
 
         // Reconstruct the file: CSS import at top, then existing content with setBasePath import and call inserted
         const newLines = [...lines]

--- a/packages/create-terra-ui-app/boilerplates/nextjs/framework.js
+++ b/packages/create-terra-ui-app/boilerplates/nextjs/framework.js
@@ -67,7 +67,7 @@ export async function create(nextTask, outputDir, boilerplatesDir, appName) {
             "import { setBasePath } from '@nasa-terra/components/dist/utilities/base-path.js'"
 
         // Create the setBasePath call with comments (with newline before it)
-        const setBasePathCall = `\n/**\n * Sets the base path to the Terra UI CDN\n *\n * If you'd rather host the assets locally, you should setup a build task to copy the assets locally and\n * set the base path to your local public folder\n * (see https://terra-ui.netlify.app/frameworks/react/#installation for more information)\n */\nsetBasePath('https://cdn.jsdelivr.net/npm/@nasa-terra/components@0.0.193/cdn/')`
+        const setBasePathCall = `\n/**\n * Sets the base path to the Terra UI CDN\n *\n * If you'd rather host the assets locally, you should setup a build task to copy the assets locally and\n * set the base path to your local public folder\n * (see https://terra-ui.netlify.app/frameworks/react/#installation for more information)\n */\nsetBasePath('https://cdn.jsdelivr.net/npm/@nasa-terra/components@0.0.194/cdn/')`
 
         // Reconstruct the file: CSS import at top, then existing content with setBasePath import and call inserted
         const newLines = [...lines]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "terra_ui_components"
 dependencies = ["anywidget>=0.9"]
-version = "0.0.191"
+version = "0.0.192"
 readme = "README.md"
 description = "NASA Terra UI Components Library"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "terra_ui_components"
 dependencies = ["anywidget>=0.9"]
-version = "0.0.193"
+version = "0.0.194"
 readme = "README.md"
 description = "NASA Terra UI Components Library"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "terra_ui_components"
 dependencies = ["anywidget>=0.9"]
-version = "0.0.192"
+version = "0.0.193"
 readme = "README.md"
 description = "NASA Terra UI Components Library"
 requires-python = ">=3.8"

--- a/src/apis/__tests__/harmony.api.test.ts
+++ b/src/apis/__tests__/harmony.api.test.ts
@@ -121,8 +121,29 @@ describe('HarmonyAPI', () => {
             })
         })
 
+        it('should route createJob through the anonymous proxy when no bearer token is provided', async () => {
+            apiGetStub.resolves({ id: 'job-anon' })
+
+            await harmonyApi.createJob(
+                {
+                    hasShape: false,
+                    requestUrl:
+                        'https://harmony.earthdata.nasa.gov/C123/ogc-api-coverages/1.0.0/rangeset?subset=lat(0:1)',
+                } as any,
+            )
+
+            expect(apiGetStub.calledOnce).to.be.true
+            expect(apiGetStub.firstCall.args[0]).to.equal(
+                'https://sjldutoe6c.execute-api.us-east-1.amazonaws.com/default/harmony-proxy/C123/ogc-api-coverages/1.0.0/rangeset?subset=lat(0:1)',
+            )
+            expect(apiGetStub.firstCall.args[1]).to.deep.equal({
+                signal: undefined,
+                headers: {},
+            })
+        })
+
         it('should request job status from PROD URL when authenticated', async () => {
-            apiGetStub.resolves({ status: 'running' })
+            apiGetStub.resolves({ status: 'running', links: [] })
 
             await harmonyApi.getJobStatus('abc123', {
                 bearerToken: 'token',

--- a/src/apis/harmony.api.ts
+++ b/src/apis/harmony.api.ts
@@ -246,12 +246,21 @@ class HarmonyApi {
 
     /**
      * Create a subset job by sending a GET request to the Harmony OGC API endpoint.
-     * The harmonyRequest.requestUrl contains the full URL with all subset parameters.
+     * When the request includes a shape, sends a multipart POST with all params in the
+     * form body alongside the shapefile (per HARMONY-290, query params + file upload
+     * cannot be combined).
      */
     async createJob(
         harmonyRequest: HarmonyRequest,
         options?: SearchOptions,
     ): Promise<SubsetJobStatus> {
+        if (harmonyRequest.hasShape) {
+            return this.#request<SubsetJobStatus>(
+                harmonyRequest.baseUrl,
+                options,
+                harmonyRequest.buildFormData(),
+            )
+        }
         return this.#request<SubsetJobStatus>(
             harmonyRequest.requestUrl,
             options,
@@ -266,7 +275,35 @@ class HarmonyApi {
         jobId: string,
         options?: SearchOptions,
     ): Promise<SubsetJobStatus> {
-        return this.#request<SubsetJobStatus>(`jobs/${jobId}`, options)
+        const status = await this.#request<SubsetJobStatus>(
+            `jobs/${jobId}`,
+            options,
+        )
+        status.links = status.links.map((link) =>
+            HarmonyApi.normalizeJobLink(link),
+        )
+        return status
+    }
+
+    /**
+     * Normalizes a job link so that data links with a missing or generic title
+     * ("OPeNDAP Request URL") get a more informative title derived from the href.
+     * Everything after `/granules/` in the URL is used; if that segment is not
+     * present the full href is used as a fallback.
+     */
+    static normalizeJobLink(link: SubsetJobLink): SubsetJobLink {
+        const isFallbackTitle =
+            !link.title ||
+            link.title === 'OPeNDAP Request URL' ||
+            link.title === 'OPeNAP Request URL'
+        if (!isFallbackTitle || link.rel !== 'data') return link
+
+        const granulesIdx = link.href.indexOf('/granules/')
+        const title =
+            granulesIdx !== -1
+                ? link.href.slice(granulesIdx + '/granules/'.length)
+                : link.href
+        return { ...link, title }
     }
 
     /**
@@ -316,7 +353,7 @@ class HarmonyApi {
         return this.#request(relativeUrl, options)
     }
 
-    #request<T>(url: string, options?: SearchOptions) {
+    #request<T>(url: string, options?: SearchOptions, body?: FormData) {
         let environmentUrl = HARMONY_URLS[Environments.PROD] // TODO: support for UAT
 
         if (!options?.bearerToken) {
@@ -329,13 +366,22 @@ class HarmonyApi {
             url = `${environmentUrl}/${url}`
         }
 
+        const headers: HeadersInit = {
+            ...(options?.bearerToken && {
+                Authorization: `Bearer ${options.bearerToken}`,
+            }),
+        }
+
+        if (body) {
+            return apiClient.post<T>(url, body, {
+                signal: options?.signal,
+                headers,
+            })
+        }
+
         return apiClient.get<T>(url, {
             signal: options?.signal,
-            headers: {
-                ...(options?.bearerToken && {
-                    Authorization: `Bearer ${options.bearerToken}`,
-                }),
-            },
+            headers,
         })
     }
 

--- a/src/apis/harmony.api.ts
+++ b/src/apis/harmony.api.ts
@@ -364,6 +364,12 @@ class HarmonyApi {
         if (!url.startsWith('http')) {
             // if url is a relative path, prepend the base Harmony URL
             url = `${environmentUrl}/${url}`
+        } else if (!options?.bearerToken) {
+            // if url is an absolute Harmony URL but the user is anonymous (no bearer token),
+            // replace the Harmony base URL with the anonymous proxy so the request is routed correctly
+            url = url
+                .replace(HARMONY_URLS[Environments.PROD], HARMONY_URLS.ANONYMOUS_ACCESS)
+                .replace(HARMONY_URLS[Environments.UAT], HARMONY_URLS.ANONYMOUS_ACCESS)
         }
 
         const headers: HeadersInit = {

--- a/src/components/data-rods/data-rods.component.ts
+++ b/src/components/data-rods/data-rods.component.ts
@@ -100,6 +100,14 @@ export default class TerraDataRods extends TerraElement {
 
     @state() private lastChanged?: LastChanged
 
+    @state() private isDateSliderDisabled = false
+
+    @state()
+    private chunkProgress?: {
+        currentChunk: number
+        totalChunks: number
+    }
+
     /**
      * add a warning state
      */
@@ -213,6 +221,8 @@ export default class TerraDataRods extends TerraElement {
                 bearer-token=${this.bearerToken}
                 show-citation=${true}
                 cache
+                @terra-time-series-chunk-progress-change=${this.#handleChunkProgressChange}
+                @terra-time-series-loading-change=${this.#handleTimeSeriesLoadingChange}
                 @terra-date-range-change=${this.#handleTimeSeriesDateRangeChange}
             >
                 <li slot="help-links">
@@ -229,9 +239,18 @@ export default class TerraDataRods extends TerraElement {
                 max-date=${maxDate}
                 start-date=${this.startDate}
                 end-date=${this.endDate}
+                .disabled=${this.isDateSliderDisabled}
                 @terra-date-range-change="${this.#handleDateRangeSliderChangeEvent}"
                 @terra-date-selection-invalid="${this.#handleInvalidDateSelection}"
             ></terra-date-range-slider>
+            ${
+                this.isDateSliderDisabled && this.chunkProgress
+                    ? html`<div class="chunk-progress" style="margin-top: 8px; color: #555; font-size: 0.95em;">
+                          Loading chunk ${this.chunkProgress.currentChunk} of
+                          ${this.chunkProgress.totalChunks}&hellip;
+                      </div>`
+                    : null
+            }
             ${
                 this.dateErrorMessage
                     ? html`<div class="date-error" style="color: red;">
@@ -246,8 +265,29 @@ export default class TerraDataRods extends TerraElement {
      * anytime the date range slider changes, update the start and end date
      */
     #handleDateRangeSliderChangeEvent(event: TerraDateRangeChangeEvent) {
+        // Lock slider immediately to avoid overlapping range requests.
+        this.isDateSliderDisabled = true
         this.startDate = event.detail.startDate
         this.endDate = event.detail.endDate
+    }
+
+    #handleTimeSeriesLoadingChange(event: CustomEvent<{ loading: boolean }>) {
+        this.isDateSliderDisabled = event.detail.loading
+
+        if (!event.detail.loading) {
+            this.chunkProgress = undefined
+        }
+    }
+
+    #handleChunkProgressChange(
+        event: CustomEvent<{ currentChunk: number; totalChunks: number }>,
+    ) {
+        const { currentChunk, totalChunks } = event.detail
+
+        this.chunkProgress =
+            currentChunk > 0 && totalChunks > 1
+                ? { currentChunk, totalChunks }
+                : undefined
     }
 
     /**

--- a/src/components/data-rods/data-rods.test.ts
+++ b/src/components/data-rods/data-rods.test.ts
@@ -1,0 +1,113 @@
+import { expect, fixture, html } from '@open-wc/testing'
+import './data-rods.js'
+
+type TestDataRodsElement = HTMLElement & {
+    updateComplete: Promise<unknown>
+}
+
+describe('<terra-data-rods>', () => {
+    it('disables the date slider immediately on user range change', async () => {
+        const el = await fixture<TestDataRodsElement>(
+            html`<terra-data-rods></terra-data-rods>`,
+        )
+
+        const slider = el.shadowRoot?.querySelector(
+            'terra-date-range-slider',
+        ) as HTMLElement & { disabled: boolean }
+
+        expect(slider.disabled).to.equal(false)
+
+        slider.dispatchEvent(
+            new CustomEvent('terra-date-range-change', {
+                detail: {
+                    startDate: '2016-01-01',
+                    endDate: '2016-08-01',
+                },
+                bubbles: true,
+                composed: true,
+            }),
+        )
+
+        await el.updateComplete
+
+        expect(slider.disabled).to.equal(true)
+    })
+
+    it('re-enables the date slider when time-series loading completes', async () => {
+        const el = await fixture<TestDataRodsElement>(
+            html`<terra-data-rods></terra-data-rods>`,
+        )
+
+        const slider = el.shadowRoot?.querySelector(
+            'terra-date-range-slider',
+        ) as HTMLElement & { disabled: boolean }
+        const timeSeries = el.shadowRoot?.querySelector('terra-time-series')
+
+        slider.dispatchEvent(
+            new CustomEvent('terra-date-range-change', {
+                detail: {
+                    startDate: '2016-01-01',
+                    endDate: '2016-08-01',
+                },
+                bubbles: true,
+                composed: true,
+            }),
+        )
+
+        await el.updateComplete
+        expect(slider.disabled).to.equal(true)
+
+        timeSeries?.dispatchEvent(
+            new CustomEvent('terra-time-series-loading-change', {
+                detail: { loading: false },
+                bubbles: true,
+                composed: true,
+            }),
+        )
+
+        await el.updateComplete
+
+        expect(slider.disabled).to.equal(false)
+    })
+
+    it('shows chunk progress while the slider is disabled for chunked requests', async () => {
+        const el = await fixture<TestDataRodsElement>(
+            html`<terra-data-rods></terra-data-rods>`,
+        )
+
+        const timeSeries = el.shadowRoot?.querySelector('terra-time-series')
+
+        timeSeries?.dispatchEvent(
+            new CustomEvent('terra-time-series-loading-change', {
+                detail: { loading: true },
+                bubbles: true,
+                composed: true,
+            }),
+        )
+        timeSeries?.dispatchEvent(
+            new CustomEvent('terra-time-series-chunk-progress-change', {
+                detail: { currentChunk: 2, totalChunks: 4 },
+                bubbles: true,
+                composed: true,
+            }),
+        )
+
+        await el.updateComplete
+
+        expect(el.shadowRoot?.textContent).to.include('Loading chunk 2 of 4')
+
+        timeSeries?.dispatchEvent(
+            new CustomEvent('terra-time-series-loading-change', {
+                detail: { loading: false },
+                bubbles: true,
+                composed: true,
+            }),
+        )
+
+        await el.updateComplete
+
+        expect(el.shadowRoot?.textContent).to.not.include(
+            'Loading chunk 2 of 4',
+        )
+    })
+})

--- a/src/components/data-subsetter/data-subsetter.component.ts
+++ b/src/components/data-subsetter/data-subsetter.component.ts
@@ -162,6 +162,12 @@ export default class TerraDataSubsetter extends QueryClientMixin(TerraElement) {
     spatialSelection?: LatLng | LatLngBounds
 
     @state()
+    shapeGeoJson?: object
+
+    @state()
+    spatialLabel?: string
+
+    @state()
     selectedDateRange: { startDate: string | null; endDate: string | null } = {
         startDate: null,
         endDate: null,
@@ -1386,9 +1392,15 @@ export default class TerraDataSubsetter extends QueryClientMixin(TerraElement) {
 
     #renderSpatialSelection() {
         const showError =
-            this.touchedFields.has('spatial') && !this.spatialSelection
+            this.touchedFields.has('spatial') &&
+            !this.spatialSelection &&
+            !this.shapeGeoJson
         const spatialString =
-            this.spatialSelection?.toString() ?? this.spatialSelection
+            this.spatialLabel ?? this.spatialSelection?.toString() ?? undefined
+        // Only pass coordinate strings as initialValue — labels like "Polygon (N vertices)"
+        // would be put into the text input and fail coordinate validation on blur.
+        const spatialInitialValue =
+            this.spatialSelection?.toString() ?? undefined
 
         return html`
             <terra-accordion>
@@ -1424,7 +1436,15 @@ export default class TerraDataSubsetter extends QueryClientMixin(TerraElement) {
                             this.#collectionController.spatialConstraints ||
                             '-180, -90, 180, 90'
                         }
-                        .initialValue=${spatialString}
+                        .initialValue=${spatialInitialValue}
+                        ?has-shape-selector=${
+                            this.collectionWithServices?.summary?.subsetting
+                                ?.shape ?? false
+                        }
+                        ?show-polygon-selection=${
+                            this.collectionWithServices?.summary?.subsetting
+                                ?.shape ?? false
+                        }
                         @terra-map-change=${this.#handleSpatialChange}
                     ></terra-spatial-picker>
                     <div
@@ -1445,11 +1465,46 @@ export default class TerraDataSubsetter extends QueryClientMixin(TerraElement) {
         this.#markFieldTouched('spatial')
 
         if (e.detail.type === MapEventType.POINT) {
+            this.shapeGeoJson = undefined
+            this.spatialLabel = undefined
             this.spatialSelection = e.detail.latLng
         } else if (e.detail.type === MapEventType.BBOX) {
+            this.shapeGeoJson = undefined
+            this.spatialLabel = undefined
             this.spatialSelection = e.detail.bounds
+        } else if (e.detail.type === MapEventType.POLYGON) {
+            this.spatialSelection = undefined
+            if (e.detail.geoJson) {
+                // Shape loaded from the shape selector dropdown
+                this.shapeGeoJson = e.detail.geoJson
+                this.spatialLabel = e.detail.label ?? 'Shape selected'
+            } else if (e.detail.latLngs.length > 0) {
+                // Polygon drawn freehand on the map — convert to GeoJSON
+                const coords = e.detail.latLngs.map((ll) => [ll.lng, ll.lat])
+                // Close the ring
+                coords.push(coords[0])
+                this.shapeGeoJson = {
+                    type: 'FeatureCollection',
+                    features: [
+                        {
+                            type: 'Feature',
+                            geometry: {
+                                type: 'Polygon',
+                                coordinates: [coords],
+                            },
+                            properties: null,
+                        },
+                    ],
+                }
+                this.spatialLabel = `Polygon (${e.detail.latLngs.length} vertices)`
+            } else {
+                this.shapeGeoJson = undefined
+                this.spatialLabel = undefined
+            }
         } else {
             this.spatialSelection = undefined
+            this.shapeGeoJson = undefined
+            this.spatialLabel = undefined
         }
     }
 
@@ -1458,6 +1513,8 @@ export default class TerraDataSubsetter extends QueryClientMixin(TerraElement) {
      */
     #resetSpatialSelection = () => {
         this.spatialSelection = undefined
+        this.shapeGeoJson = undefined
+        this.spatialLabel = undefined
         this.spatialPicker.clear()
 
         this.#markFieldTouched('spatial')
@@ -2556,6 +2613,10 @@ export default class TerraDataSubsetter extends QueryClientMixin(TerraElement) {
             location: this.spatialSelection,
         })
 
+        if (this.shapeGeoJson) {
+            harmonyRequest.shape(this.shapeGeoJson)
+        }
+
         if (
             this.collectionWithServices?.summary.subsetting.temporal &&
             this.selectedDateRange.startDate &&
@@ -2610,7 +2671,26 @@ export default class TerraDataSubsetter extends QueryClientMixin(TerraElement) {
         // add a label to identify the subsetter as the source
         harmonyRequest.label('terra-data-subsetter')
 
-        console.log('Creating Harmony job with request:', harmonyRequest)
+        // add metadata labels describing the request
+        const cwsShortName =
+            this.collectionWithServices?.shortName ??
+            this.collectionWithServices?.collection?.ShortName
+        const cwsVersion = this.collectionWithServices?.collection?.Version
+        const cwsEntryTitle =
+            this.collectionWithServices?.collection?.EntryTitle
+
+        if (cwsShortName && cwsVersion) {
+            harmonyRequest.label(
+                `collection-entry-id: ${cwsShortName}_${cwsVersion}`.toLowerCase(),
+            )
+        }
+        if (cwsEntryTitle) {
+            harmonyRequest.label(
+                `collection-entry-title: ${cwsEntryTitle.toLowerCase()}`,
+            )
+        }
+
+        console.log('Creating Harmony job with request:', harmonyRequest.params)
 
         const job = await this.#harmonyRequestController.startJob({
             harmonyRequest,

--- a/src/components/data-subsetter/data-subsetter.component.ts
+++ b/src/components/data-subsetter/data-subsetter.component.ts
@@ -53,6 +53,7 @@ import {
     type ConfiguredOutputFormat,
     type Variable,
 } from '../../apis/harmony.api.js'
+import { HttpException } from '../../exceptions/http.exception.js'
 
 const defaultOutputFormat: ConfiguredOutputFormat = {
     key: 'application/x-netcdf4',
@@ -210,6 +211,9 @@ export default class TerraDataSubsetter extends QueryClientMixin(TerraElement) {
     validationError?: string
 
     @state()
+    harmonyRequestError?: string
+
+    @state()
     granuleMinDate?: string
 
     @state()
@@ -347,7 +351,9 @@ export default class TerraDataSubsetter extends QueryClientMixin(TerraElement) {
 
     render() {
         const showJobStatus =
-            this.#harmonyRequestController.jobId && !this.refineParameters
+            (this.#harmonyRequestController.jobId ||
+                this.harmonyRequestError) &&
+            !this.refineParameters
         const showMinimizeButton = showJobStatus && !!this.dialog
         const title =
             this.collectionWithServices?.collection?.EntryTitle ??
@@ -565,9 +571,15 @@ export default class TerraDataSubsetter extends QueryClientMixin(TerraElement) {
 
     #renderFooterForDialog() {
         const showJobStatus =
-            this.#harmonyRequestController.jobId && !this.refineParameters
+            (this.#harmonyRequestController.jobId ||
+                this.harmonyRequestError) &&
+            !this.refineParameters
 
-        if (showJobStatus && this.#harmonyRequestController.jobId) {
+        if (showJobStatus) {
+            if (!this.#harmonyRequestController.jobId) {
+                return nothing
+            }
+
             // Job status footer - return the footer content with slot="footer"
             return html`
                 <div slot="footer" class="footer">
@@ -700,7 +712,9 @@ export default class TerraDataSubsetter extends QueryClientMixin(TerraElement) {
                     </div>
                 </div>
             `
-        } else if (this.dataAccessMode === 'subset') {
+        }
+
+        if (this.dataAccessMode === 'subset') {
             // Get Data footer
             return html`
                 <div slot="footer" class="footer">
@@ -709,20 +723,18 @@ export default class TerraDataSubsetter extends QueryClientMixin(TerraElement) {
                         <button class="btn btn-primary" @click=${this.#getData}>
                             Get Data
                         </button>
-                            ${
-                                this.jobId
-                                    ? html`
-                                          <terra-button
-                                              variant="default"
-                                              @click=${this.#viewRunningJob}
-                                          >
-                                              View Running Job
-                                          </terra-button>
-                                      `
-                                    : nothing
-                            }
-                            </div>
-                        </div>
+                        ${
+                            this.jobId
+                                ? html`
+                                      <terra-button
+                                          variant="default"
+                                          @click=${this.#viewRunningJob}
+                                      >
+                                          View Running Job
+                                      </terra-button>
+                                  `
+                                : nothing
+                        }
                     </div>
                 </div>
             `
@@ -894,12 +906,12 @@ export default class TerraDataSubsetter extends QueryClientMixin(TerraElement) {
                       <div class="footer">
                           <button class="btn btn-secondary" @click=${this.#resetAllParameters}>Reset All</button>
                           <div>
-                          <button
-                              class="btn btn-primary"
-                              @click=${this.#getData}
-                          >
-                              Get Data
-                          </button>
+                              <button
+                                  class="btn btn-primary"
+                                  @click=${this.#getData}
+                              >
+                                  Get Data
+                              </button>
                                   ${
                                       this.jobId
                                           ? html`
@@ -912,8 +924,6 @@ export default class TerraDataSubsetter extends QueryClientMixin(TerraElement) {
                                             `
                                           : nothing
                                   }
-                              </div>
-                                </div>
                           </div>
                       </div>
                   `
@@ -2159,17 +2169,30 @@ export default class TerraDataSubsetter extends QueryClientMixin(TerraElement) {
                 </div>
 
                 <div class="progress-container">
-                    <div class="progress-text">
-                        <span class="spinner"></span>
-                        <span class="status-running">Searching for data...</span>
-                    </div>
+                ${
+                    this.harmonyRequestError
+                        ? html`
+                          <terra-alert open variant="danger" appearance="white">
+                              ${this.#renderHarmonyRequestError()}
+                          </terra-alert>
+                      `
+                        : html`
+                          <div class="progress-container">
+                              <div class="progress-text">
+                                  <span class="spinner"></span>
+                                  <span class="status-running"
+                                      >Searching for data...</span
+                                  >
+                              </div>
 
-                    <div class="progress-bar">
-                        <div class="progress-fill" style="width: 0%"></div>
-                    </div>
-                </div>
+                              <div class="progress-bar">
+                                  <div class="progress-fill" style="width: 0%"></div>
+                              </div>
+                          </div>
 
-                ${this.#renderJobMessage()}
+                          ${this.#renderJobMessage()}
+                      `
+                }
             </div>`
         }
 
@@ -2581,6 +2604,8 @@ export default class TerraDataSubsetter extends QueryClientMixin(TerraElement) {
     }
 
     async #getData() {
+        this.harmonyRequestError = undefined
+
         // Validate before proceeding
         const validationError = this.#getGiovanniValidationError()
         if (validationError) {
@@ -2692,12 +2717,19 @@ export default class TerraDataSubsetter extends QueryClientMixin(TerraElement) {
 
         console.log('Creating Harmony job with request:', harmonyRequest.params)
 
-        const job = await this.#harmonyRequestController.startJob({
-            harmonyRequest,
-            options: { bearerToken: this.bearerToken },
-        })
+        try {
+            const job = await this.#harmonyRequestController.startJob({
+                harmonyRequest,
+                options: { bearerToken: this.bearerToken },
+            })
 
-        this.jobId = job.jobID
+            this.jobId = job.jobID
+        } catch (error) {
+            this.harmonyRequestError =
+                this.#getHarmonyRequestErrorMessage(error)
+            this.refineParameters = false
+            return
+        }
 
         // scroll the job-status-section into view
         setTimeout(() => {
@@ -2872,6 +2904,7 @@ export default class TerraDataSubsetter extends QueryClientMixin(TerraElement) {
 
     #backToSubsetOptions() {
         this.refineParameters = true
+        this.harmonyRequestError = undefined
         // Scroll to the top of the component
         setTimeout(() => {
             const container = this.renderRoot.querySelector('.container')
@@ -3125,5 +3158,57 @@ export default class TerraDataSubsetter extends QueryClientMixin(TerraElement) {
         }
 
         return null
+    }
+
+    #getHarmonyRequestErrorMessage(error: unknown): string {
+        if (error instanceof HttpException) {
+            const sanitizedMessage = error.message
+                ?.replace(/^Error:\s*/i, '')
+                .trim()
+
+            if (
+                sanitizedMessage
+                    ?.toLowerCase()
+                    .includes('no matching granules found')
+            ) {
+                return 'No matching granules were found for your subset request. Please try expanding your search'
+            }
+
+            if (sanitizedMessage) {
+                return sanitizedMessage
+            }
+        }
+
+        return 'Unable to create your subset request. Please try again.'
+    }
+
+    #renderHarmonyRequestError() {
+        if (!this.harmonyRequestError) {
+            return nothing
+        }
+
+        const noGranulesMessage =
+            'No matching granules were found for your subset request. Please try expanding your search'
+
+        if (this.harmonyRequestError === noGranulesMessage) {
+            return html`
+                No matching granules were found for your subset request. Please
+                try
+                <a
+                    href="#"
+                    @click=${this.#handleExpandSearchClick}
+                    style="color: inherit; text-decoration: underline; font-weight: 600;"
+                >
+                    expanding your search
+                </a>
+            `
+        }
+
+        return this.harmonyRequestError
+    }
+
+    #handleExpandSearchClick = (event: Event) => {
+        event.preventDefault()
+        this.#backToSubsetOptions()
     }
 }

--- a/src/components/data-subsetter/data-subsetter.test.ts
+++ b/src/components/data-subsetter/data-subsetter.test.ts
@@ -1,279 +1,379 @@
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing'
+import {
+    elementUpdated,
+    expect,
+    fixture,
+    html,
+    waitUntil,
+} from '@open-wc/testing'
+import { HarmonyRequestController } from '../../controllers/harmony-request.controller.js'
+import { HttpException } from '../../exceptions/http.exception.js'
 import './data-subsetter.js'
 
 const getAccordionContent = (el: any) => {
-	const accordions = Array.from(
-		el.shadowRoot?.querySelectorAll('terra-accordion') ?? [],
-	) as Element[]
+    const accordions = Array.from(
+        el.shadowRoot?.querySelectorAll('terra-accordion') ?? [],
+    ) as Element[]
 
-	const dimensionsAccordion = accordions.find((acc) =>
-		acc.textContent?.includes('Select Dimensions:'),
-	)
+    const dimensionsAccordion = accordions.find((acc) =>
+        acc.textContent?.includes('Select Dimensions:'),
+    )
 
-	return dimensionsAccordion?.querySelector('.accordion-content')
+    return dimensionsAccordion?.querySelector('.accordion-content')
 }
 
 describe('<terra-data-subsetter> dimension intersection support', () => {
-	it('renders common dimensions for all available variables when no variable selected', async () => {
-		const el: any = await fixture(
-			html`<terra-data-subsetter></terra-data-subsetter>`,
-		)
+    it('renders common dimensions for all available variables when no variable selected', async () => {
+        const el: any = await fixture(
+            html`<terra-data-subsetter></terra-data-subsetter>`,
+        )
 
-		el.collectionWithServices = {
-			conceptId: 'C1',
-			shortName: 'S1',
-			variableSubset: true,
-			bboxSubset: false,
-			temporalSubset: false,
-			concatenate: false,
-			reproject: false,
-			capabilitiesVersion: '1',
-			outputFormats: [],
-			services: [],
-			variables: [],
-			collection: {
-				ShortName: 'S1',
-				Version: '1',
-				granuleCount: 0,
-				EntryTitle: 'Test',
-				SpatialExtent: {
-					GranuleSpatialRepresentation: 'N/A',
-					HorizontalSpatialDomain: {
-						Geometry: {
-							CoordinateSystem: 'EPSG:4326',
-							BoundingRectangles: {
-								WestBoundingCoordinate: 0,
-								NorthBoundingCoordinate: 0,
-								EastBoundingCoordinate: 0,
-								SouthBoundingCoordinate: 0,
-							},
-						},
-					},
-				},
-				TemporalExtents: [],
-			},
-		}
+        el.collectionWithServices = {
+            conceptId: 'C1',
+            shortName: 'S1',
+            variableSubset: true,
+            bboxSubset: false,
+            temporalSubset: false,
+            concatenate: false,
+            reproject: false,
+            capabilitiesVersion: '1',
+            outputFormats: [],
+            services: [],
+            variables: [],
+            collection: {
+                ShortName: 'S1',
+                Version: '1',
+                granuleCount: 0,
+                EntryTitle: 'Test',
+                SpatialExtent: {
+                    GranuleSpatialRepresentation: 'N/A',
+                    HorizontalSpatialDomain: {
+                        Geometry: {
+                            CoordinateSystem: 'EPSG:4326',
+                            BoundingRectangles: {
+                                WestBoundingCoordinate: 0,
+                                NorthBoundingCoordinate: 0,
+                                EastBoundingCoordinate: 0,
+                                SouthBoundingCoordinate: 0,
+                            },
+                        },
+                    },
+                },
+                TemporalExtents: [],
+            },
+        }
 
-		el.dataAccessMode = 'subset'
+        el.dataAccessMode = 'subset'
 
-		el.variablesQuery = {
-			result: {
-				data: {
-					hits: 2,
-					items: [
-						{
-							umm: {
-								Name: 'var1',
-								Dimensions: [
-									{ Name: 'DimA', Size: 5, Type: 'OTHER' },
-									{
-										Name: 'time',
-										Size: 10,
-										Type: 'TIME_DIMENSION',
-									},
-								],
-							},
-						},
-						{
-							umm: {
-								Name: 'var2',
-								Dimensions: [
-									{ Name: 'DimA', Size: 5, Type: 'OTHER' },
-									{
-										Name: 'lat',
-										Size: 180,
-										Type: 'LATITUDE_DIMENSION',
-									},
-								],
-							},
-						},
-					],
-				},
-			},
-		}
+        el.variablesQuery = {
+            result: {
+                data: {
+                    hits: 2,
+                    items: [
+                        {
+                            umm: {
+                                Name: 'var1',
+                                Dimensions: [
+                                    { Name: 'DimA', Size: 5, Type: 'OTHER' },
+                                    {
+                                        Name: 'time',
+                                        Size: 10,
+                                        Type: 'TIME_DIMENSION',
+                                    },
+                                ],
+                            },
+                        },
+                        {
+                            umm: {
+                                Name: 'var2',
+                                Dimensions: [
+                                    { Name: 'DimA', Size: 5, Type: 'OTHER' },
+                                    {
+                                        Name: 'lat',
+                                        Size: 180,
+                                        Type: 'LATITUDE_DIMENSION',
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
+            },
+        }
 
-		await elementUpdated(el)
+        await elementUpdated(el)
 
-		const accordionContent = getAccordionContent(el)
+        const accordionContent = getAccordionContent(el)
 
-		expect(el.shadowRoot?.textContent).to.include('Select Dimensions:')
-		expect(accordionContent?.textContent).to.include('DimA')
-		expect(accordionContent?.textContent).to.not.include('time')
-		expect(accordionContent?.textContent).to.not.include('lat')
-	})
+        expect(el.shadowRoot?.textContent).to.include('Select Dimensions:')
+        expect(accordionContent?.textContent).to.include('DimA')
+        expect(accordionContent?.textContent).to.not.include('time')
+        expect(accordionContent?.textContent).to.not.include('lat')
+    })
 
-	it('shows union dimensions when one selected variable has no dimensions', async () => {
-		const el: any = await fixture(
-			html`<terra-data-subsetter></terra-data-subsetter>`,
-		)
+    it('shows union dimensions when one selected variable has no dimensions', async () => {
+        const el: any = await fixture(
+            html`<terra-data-subsetter></terra-data-subsetter>`,
+        )
 
-		el.collectionWithServices = {
-			conceptId: 'C1',
-			shortName: 'S1',
-			variableSubset: true,
-			bboxSubset: false,
-			temporalSubset: false,
-			concatenate: false,
-			reproject: false,
-			capabilitiesVersion: '1',
-			outputFormats: [],
-			services: [],
-			variables: [],
-			collection: {
-				ShortName: 'S1',
-				Version: '1',
-				granuleCount: 0,
-				EntryTitle: 'Test',
-				SpatialExtent: {
-					GranuleSpatialRepresentation: 'N/A',
-					HorizontalSpatialDomain: {
-						Geometry: {
-							CoordinateSystem: 'EPSG:4326',
-							BoundingRectangles: {
-								WestBoundingCoordinate: 0,
-								NorthBoundingCoordinate: 0,
-								EastBoundingCoordinate: 0,
-								SouthBoundingCoordinate: 0,
-							},
-						},
-					},
-				},
-				TemporalExtents: [],
-			},
-		}
+        el.collectionWithServices = {
+            conceptId: 'C1',
+            shortName: 'S1',
+            variableSubset: true,
+            bboxSubset: false,
+            temporalSubset: false,
+            concatenate: false,
+            reproject: false,
+            capabilitiesVersion: '1',
+            outputFormats: [],
+            services: [],
+            variables: [],
+            collection: {
+                ShortName: 'S1',
+                Version: '1',
+                granuleCount: 0,
+                EntryTitle: 'Test',
+                SpatialExtent: {
+                    GranuleSpatialRepresentation: 'N/A',
+                    HorizontalSpatialDomain: {
+                        Geometry: {
+                            CoordinateSystem: 'EPSG:4326',
+                            BoundingRectangles: {
+                                WestBoundingCoordinate: 0,
+                                NorthBoundingCoordinate: 0,
+                                EastBoundingCoordinate: 0,
+                                SouthBoundingCoordinate: 0,
+                            },
+                        },
+                    },
+                },
+                TemporalExtents: [],
+            },
+        }
 
-		el.dataAccessMode = 'subset'
+        el.dataAccessMode = 'subset'
 
-		el.variablesQuery = {
-			result: {
-				data: {
-					hits: 2,
-					items: [
-						{
-							umm: {
-								Name: 'var1',
-								Dimensions: [],
-							},
-						},
-						{
-							umm: {
-								Name: 'var2',
-								Dimensions: [{ Name: 'DimA', Size: 4, Type: 'OTHER' }],
-							},
-						},
-					],
-				},
-			},
-		}
+        el.variablesQuery = {
+            result: {
+                data: {
+                    hits: 2,
+                    items: [
+                        {
+                            umm: {
+                                Name: 'var1',
+                                Dimensions: [],
+                            },
+                        },
+                        {
+                            umm: {
+                                Name: 'var2',
+                                Dimensions: [
+                                    { Name: 'DimA', Size: 4, Type: 'OTHER' },
+                                ],
+                            },
+                        },
+                    ],
+                },
+            },
+        }
 
-		el.selectedVariables = [
-			{ name: 'var1', href: '', conceptId: 'C1' },
-			{ name: 'var2', href: '', conceptId: 'C2' },
-		]
+        el.selectedVariables = [
+            { name: 'var1', href: '', conceptId: 'C1' },
+            { name: 'var2', href: '', conceptId: 'C2' },
+        ]
 
-		await elementUpdated(el)
+        await elementUpdated(el)
 
-		const accordionContent = getAccordionContent(el)
+        const accordionContent = getAccordionContent(el)
 
-		expect(el.shadowRoot?.textContent).to.include('Select Dimensions:')
-		expect(accordionContent?.textContent).to.include('DimA')
-	})
+        expect(el.shadowRoot?.textContent).to.include('Select Dimensions:')
+        expect(accordionContent?.textContent).to.include('DimA')
+    })
 
-	it('renders only common dimensions and excludes time/lat/lon', async () => {
-		const el: any = await fixture(
-			html`<terra-data-subsetter></terra-data-subsetter>`,
-		)
+    it('renders only common dimensions and excludes time/lat/lon', async () => {
+        const el: any = await fixture(
+            html`<terra-data-subsetter></terra-data-subsetter>`,
+        )
 
-		el.collectionWithServices = {
-			conceptId: 'C1',
-			shortName: 'S1',
-			variableSubset: true,
-			bboxSubset: false,
-			temporalSubset: false,
-			concatenate: false,
-			reproject: false,
-			capabilitiesVersion: '1',
-			outputFormats: [],
-			services: [],
-			variables: [],
-			collection: {
-				ShortName: 'S1',
-				Version: '1',
-				granuleCount: 0,
-				EntryTitle: 'Test',
-				SpatialExtent: {
-					GranuleSpatialRepresentation: 'N/A',
-					HorizontalSpatialDomain: {
-						Geometry: {
-							CoordinateSystem: 'EPSG:4326',
-							BoundingRectangles: {
-								WestBoundingCoordinate: 0,
-								NorthBoundingCoordinate: 0,
-								EastBoundingCoordinate: 0,
-								SouthBoundingCoordinate: 0,
-							},
-						},
-					},
-				},
-				TemporalExtents: [],
-			},
-		}
+        el.collectionWithServices = {
+            conceptId: 'C1',
+            shortName: 'S1',
+            variableSubset: true,
+            bboxSubset: false,
+            temporalSubset: false,
+            concatenate: false,
+            reproject: false,
+            capabilitiesVersion: '1',
+            outputFormats: [],
+            services: [],
+            variables: [],
+            collection: {
+                ShortName: 'S1',
+                Version: '1',
+                granuleCount: 0,
+                EntryTitle: 'Test',
+                SpatialExtent: {
+                    GranuleSpatialRepresentation: 'N/A',
+                    HorizontalSpatialDomain: {
+                        Geometry: {
+                            CoordinateSystem: 'EPSG:4326',
+                            BoundingRectangles: {
+                                WestBoundingCoordinate: 0,
+                                NorthBoundingCoordinate: 0,
+                                EastBoundingCoordinate: 0,
+                                SouthBoundingCoordinate: 0,
+                            },
+                        },
+                    },
+                },
+                TemporalExtents: [],
+            },
+        }
 
-		el.dataAccessMode = 'subset'
+        el.dataAccessMode = 'subset'
 
-		el.variablesQuery = {
-			result: {
-				data: {
-					hits: 2,
-					items: [
-						{
-							umm: {
-								Name: 'var1',
-								Dimensions: [
-									{ Name: 'DimA', Size: 4, Type: 'OTHER' },
-									{
-										Name: 'time',
-										Size: 10,
-										Type: 'TIME_DIMENSION',
-									},
-								],
-							},
-						},
-						{
-							umm: {
-								Name: 'var2',
-								Dimensions: [
-									{ Name: 'DimA', Size: 4, Type: 'OTHER' },
-									{
-										Name: 'lat',
-										Size: 180,
-										Type: 'LATITUDE_DIMENSION',
-									},
-								],
-							},
-						},
-					],
-				},
-			},
-		}
+        el.variablesQuery = {
+            result: {
+                data: {
+                    hits: 2,
+                    items: [
+                        {
+                            umm: {
+                                Name: 'var1',
+                                Dimensions: [
+                                    { Name: 'DimA', Size: 4, Type: 'OTHER' },
+                                    {
+                                        Name: 'time',
+                                        Size: 10,
+                                        Type: 'TIME_DIMENSION',
+                                    },
+                                ],
+                            },
+                        },
+                        {
+                            umm: {
+                                Name: 'var2',
+                                Dimensions: [
+                                    { Name: 'DimA', Size: 4, Type: 'OTHER' },
+                                    {
+                                        Name: 'lat',
+                                        Size: 180,
+                                        Type: 'LATITUDE_DIMENSION',
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
+            },
+        }
 
-		el.selectedVariables = [
-			{ name: 'var1', href: '', conceptId: 'C1' },
-			{ name: 'var2', href: '', conceptId: 'C2' },
-		]
+        el.selectedVariables = [
+            { name: 'var1', href: '', conceptId: 'C1' },
+            { name: 'var2', href: '', conceptId: 'C2' },
+        ]
 
-		await elementUpdated(el)
+        await elementUpdated(el)
 
-		const accordionContent = getAccordionContent(el)
+        const accordionContent = getAccordionContent(el)
 
-		expect(el.shadowRoot?.textContent).to.include('Select Dimensions:')
-		expect(accordionContent?.textContent).to.include('DimA')
-		expect(accordionContent?.textContent).to.not.include('time')
-		expect(accordionContent?.textContent).to.not.include('lat')
+        expect(el.shadowRoot?.textContent).to.include('Select Dimensions:')
+        expect(accordionContent?.textContent).to.include('DimA')
+        expect(accordionContent?.textContent).to.not.include('time')
+        expect(accordionContent?.textContent).to.not.include('lat')
 
-		const slider = accordionContent?.querySelector('terra-slider')
-		expect(slider).to.exist
-		expect((slider as any)?.max).to.equal(4)
-		expect((slider as any)?.min).to.equal(1)
-	})
+        const slider = accordionContent?.querySelector('terra-slider')
+        expect(slider).to.exist
+        expect((slider as any)?.max).to.equal(4)
+        expect((slider as any)?.min).to.equal(1)
+    })
+})
+
+describe('<terra-data-subsetter> harmony request errors', () => {
+    it('shows Harmony validation errors on the Results view when job creation fails', async () => {
+        const originalStartJob = HarmonyRequestController.prototype.startJob
+
+        HarmonyRequestController.prototype.startJob = (async () => {
+            throw new HttpException({
+                status: 400,
+                message: 'Error: No matching granules found.',
+            })
+        }) as typeof HarmonyRequestController.prototype.startJob
+
+        try {
+            const el: any = await fixture(
+                html`<terra-data-subsetter></terra-data-subsetter>`,
+            )
+
+            el.collectionWithServices = {
+                conceptId: 'C123',
+                shortName: 'S1',
+                summary: {
+                    subsetting: {
+                        bbox: false,
+                        dimension: false,
+                        shape: false,
+                        temporal: false,
+                        variable: true,
+                    },
+                    reprojection: {
+                        supported: false,
+                        supportedProjections: [],
+                        interpolationMethods: [],
+                    },
+                    averaging: { time: false, area: false },
+                    concatenation: false,
+                    outputFormats: [],
+                },
+                services: [{ name: 'harmony', href: '', capabilities: {} }],
+                variables: [
+                    {
+                        conceptId: 'V1',
+                        name: 'Variable 1',
+                        href: '',
+                    },
+                ],
+                collection: {
+                    EntryTitle: 'Test Collection',
+                    ShortName: 'S1',
+                    Version: '1',
+                    TemporalExtents: [],
+                    SpatialExtent: {},
+                },
+            }
+
+            el.dataAccessMode = 'subset'
+            await elementUpdated(el)
+
+            const getDataButton = Array.from(
+                el.shadowRoot?.querySelectorAll('button') ?? [],
+            ).find((button) => button.textContent?.trim() === 'Get Data') as
+                | HTMLButtonElement
+                | undefined
+
+            expect(getDataButton).to.exist
+            getDataButton?.click()
+
+            await waitUntil(() => Boolean(el.harmonyRequestError))
+            await elementUpdated(el)
+
+            await waitUntil(() =>
+                Boolean(el.shadowRoot?.textContent?.includes('Results:')),
+            )
+
+            const errorAlert = Array.from(
+                el.shadowRoot?.querySelectorAll('terra-alert') ?? [],
+            ).find((alert) =>
+                alert.textContent?.includes(
+                    'No matching granules were found for your subset request. Please try expanding your search',
+                ),
+            )
+
+            expect(errorAlert).to.exist
+            expect(el.shadowRoot?.textContent).to.not.include(
+                'No matching granules found.',
+            )
+        } finally {
+            HarmonyRequestController.prototype.startJob = originalStartJob
+        }
+    })
 })

--- a/src/components/data-subsetter/notebooks/subsetter-notebook.ts
+++ b/src/components/data-subsetter/notebooks/subsetter-notebook.ts
@@ -21,7 +21,7 @@ export function getNotebook(host: TerraDataSubsetter) {
         {
             id: '2733501b-0de4-4067-8aff-864e1b4c76cb',
             cell_type: 'code',
-            source: '%pip install -q "terra_ui_components==0.0.192" "anywidget==0.9.15"',
+            source: '%pip install -q "terra_ui_components==0.0.193" "anywidget==0.9.15"',
             metadata: {
                 trusted: true,
             },

--- a/src/components/data-subsetter/notebooks/subsetter-notebook.ts
+++ b/src/components/data-subsetter/notebooks/subsetter-notebook.ts
@@ -21,7 +21,7 @@ export function getNotebook(host: TerraDataSubsetter) {
         {
             id: '2733501b-0de4-4067-8aff-864e1b4c76cb',
             cell_type: 'code',
-            source: '%pip install -q "terra_ui_components==0.0.193" "anywidget==0.9.15"',
+            source: '%pip install -q "terra_ui_components==0.0.194" "anywidget==0.9.15"',
             metadata: {
                 trusted: true,
             },

--- a/src/components/data-subsetter/notebooks/subsetter-notebook.ts
+++ b/src/components/data-subsetter/notebooks/subsetter-notebook.ts
@@ -21,7 +21,7 @@ export function getNotebook(host: TerraDataSubsetter) {
         {
             id: '2733501b-0de4-4067-8aff-864e1b4c76cb',
             cell_type: 'code',
-            source: '%pip install -q "terra_ui_components==0.0.191" "anywidget==0.9.15"',
+            source: '%pip install -q "terra_ui_components==0.0.192" "anywidget==0.9.15"',
             metadata: {
                 trusted: true,
             },

--- a/src/components/date-picker/date-picker.component.ts
+++ b/src/components/date-picker/date-picker.component.ts
@@ -83,6 +83,10 @@ export default class TerraDatePicker extends TerraElement {
     @property({ type: Boolean, attribute: 'use-end-of-day' }) useEndOfDay = true
     @property({ attribute: 'closable', type: Boolean })
     showClose: boolean = false
+    /** IANA timezone identifier for display (e.g. 'America/New_York'). Affects time display only; internal values remain UTC. */
+    @property() timezone?: string
+    /** Display time in 12-hour format with AM/PM. Requires enable-time. Internal values remain UTC. */
+    @property({ type: Boolean, attribute: 'twelve-hour' }) twelveHour = false
 
     @state() isOpen = false
     @state() leftMonth: Date = new Date()
@@ -110,6 +114,143 @@ export default class TerraDatePicker extends TerraElement {
 
     private getDefaultEndSecond() {
         return this.useEndOfDay ? 59 : 0
+    }
+
+    /**
+     * Get the display timezone offset in minutes relative to UTC for a given reference date.
+     * Returns a positive value for timezones ahead of UTC (e.g. Asia/Kolkata = +330),
+     * and a negative value for timezones behind UTC (e.g. America/New_York EST = -300).
+     * Returns 0 if no timezone is configured or if the identifier is invalid.
+     */
+    private getTimezoneOffsetMinutes(ref: Date): number {
+        if (!this.timezone) return 0
+        try {
+            const fmt = new Intl.DateTimeFormat('en-US', {
+                timeZone: this.timezone,
+                year: 'numeric',
+                month: 'numeric',
+                day: 'numeric',
+                hour: 'numeric',
+                minute: 'numeric',
+                second: 'numeric',
+                hour12: false,
+            })
+            const parts = fmt.formatToParts(ref)
+            const get = (type: string) =>
+                parseInt(
+                    parts.find((p) => p.type === type)?.value ?? '0',
+                    10,
+                )
+            const tzYear = get('year')
+            const tzMonth = get('month')
+            const tzDay = get('day')
+            // hour12: false can yield 24 for midnight in some engines
+            const tzHour = get('hour') % 24
+            const tzMinute = get('minute')
+            const tzSecond = get('second')
+            // Interpret the timezone wall-clock time as if it were UTC
+            const tzAsIfUtc = Date.UTC(
+                tzYear,
+                tzMonth - 1,
+                tzDay,
+                tzHour,
+                tzMinute,
+                tzSecond,
+            )
+            // Offset = (local wall-clock as UTC) – actual UTC ref (in minutes)
+            return Math.round((tzAsIfUtc - ref.getTime()) / 60000)
+        } catch {
+            return 0
+        }
+    }
+
+    /**
+     * Convert UTC time components to display time in the configured timezone.
+     * When no timezone is set, returns the input values unchanged.
+     */
+    private getDisplayTimeComponents(
+        utcH: number,
+        utcM: number,
+        utcS: number,
+        ref: Date | null,
+    ): { hour: number; minute: number; second: number } {
+        if (!this.timezone || !ref)
+            return { hour: utcH, minute: utcM, second: utcS }
+        const offsetMinutes = this.getTimezoneOffsetMinutes(ref)
+        let totalMinutes = utcH * 60 + utcM + offsetMinutes
+        totalMinutes = ((totalMinutes % 1440) + 1440) % 1440
+        return {
+            hour: Math.floor(totalMinutes / 60),
+            minute: totalMinutes % 60,
+            second: utcS,
+        }
+    }
+
+    /**
+     * Convert display time (in the configured timezone) back to UTC time components.
+     * When no timezone is set, returns the input values unchanged.
+     */
+    private getUtcTimeFromDisplay(
+        dispH: number,
+        dispM: number,
+        dispS: number,
+        ref: Date | null,
+    ): { hour: number; minute: number; second: number } {
+        if (!this.timezone || !ref)
+            return { hour: dispH, minute: dispM, second: dispS }
+        const offsetMinutes = this.getTimezoneOffsetMinutes(ref)
+        let totalMinutes = dispH * 60 + dispM - offsetMinutes
+        totalMinutes = ((totalMinutes % 1440) + 1440) % 1440
+        return {
+            hour: Math.floor(totalMinutes / 60),
+            minute: totalMinutes % 60,
+            second: dispS,
+        }
+    }
+
+    /** Convert a 24-hour value to 12-hour with AM/PM period. */
+    private to12Hour(hour24: number): { hour: number; period: 'AM' | 'PM' } {
+        const period: 'AM' | 'PM' = hour24 < 12 ? 'AM' : 'PM'
+        const hour = hour24 % 12 || 12
+        return { hour, period }
+    }
+
+    /** Convert a 12-hour value with AM/PM period to 24-hour. */
+    private to24Hour(hour12: number, period: 'AM' | 'PM'): number {
+        if (period === 'AM') {
+            return hour12 === 12 ? 0 : hour12
+        } else {
+            return hour12 === 12 ? 12 : hour12 + 12
+        }
+    }
+
+    /** Toggle the AM/PM period for the start or end time picker. */
+    private togglePeriod(isStart: boolean) {
+        const utcH = isStart ? this.startHour : this.endHour
+        const utcM = isStart ? this.startMinute : this.endMinute
+        const utcS = isStart ? this.startSecond : this.endSecond
+        const ref = isStart ? this.selectedStart : this.selectedEnd
+        const display = this.getDisplayTimeComponents(utcH, utcM, utcS, ref)
+        const d12 = this.to12Hour(display.hour)
+        const newPeriod: 'AM' | 'PM' = d12.period === 'AM' ? 'PM' : 'AM'
+        const newDisplayH = this.to24Hour(d12.hour, newPeriod)
+        const utc = this.getUtcTimeFromDisplay(
+            newDisplayH,
+            display.minute,
+            display.second,
+            ref,
+        )
+        if (isStart) {
+            this.startHour = utc.hour
+            this.startMinute = utc.minute
+            this.startSecond = utc.second
+        } else {
+            this.endHour = utc.hour
+            this.endMinute = utc.minute
+            this.endSecond = utc.second
+        }
+        this.emitChange()
+        this.requestUpdate()
     }
 
     @state() selectedDates = {
@@ -612,23 +753,31 @@ export default class TerraDatePicker extends TerraElement {
             this.displayFormat ||
             (this.enableTime ? 'YYYY-MM-DD HH:mm:ss' : 'YYYY-MM-DD')
 
-        // When time is enabled, use UTC date components and time picker values
+        // When time is enabled, use UTC date components and convert to display timezone
         if (this.enableTime) {
             const year = date.getUTCFullYear()
             const month = String(date.getUTCMonth() + 1).padStart(2, '0')
             const day = String(date.getUTCDate()).padStart(2, '0')
-            // Use time picker state values instead of date object's time
-            const hours = String(
+            // Convert UTC state values to display timezone
+            const display = this.getDisplayTimeComponents(
                 isStart ? this.startHour : this.endHour,
-            ).padStart(2, '0')
-            const minutes = String(
                 isStart ? this.startMinute : this.endMinute,
-            ).padStart(2, '0')
-            const seconds = String(
                 isStart ? this.startSecond : this.endSecond,
-            ).padStart(2, '0')
-
-            return format
+                date,
+            )
+            // When twelveHour is enabled and no custom displayFormat, use 12h format with AM/PM
+            if (this.twelveHour && !this.displayFormat) {
+                const d12 = this.to12Hour(display.hour)
+                const hours = String(d12.hour).padStart(2, '0')
+                const minutes = String(display.minute).padStart(2, '0')
+                const seconds = String(display.second).padStart(2, '0')
+                return `${year}-${month}-${day} ${hours}:${minutes}:${seconds} ${d12.period}`
+            }
+            const hours = String(display.hour).padStart(2, '0')
+            const minutes = String(display.minute).padStart(2, '0')
+            const seconds = String(display.second).padStart(2, '0')
+            const effectiveFormat = this.displayFormat || 'YYYY-MM-DD HH:mm:ss'
+            return effectiveFormat
                 .replace('YYYY', year.toString())
                 .replace('MM', month)
                 .replace('DD', day)
@@ -681,21 +830,35 @@ export default class TerraDatePicker extends TerraElement {
 
         // Check if it's already in YYYY-MM-DD format - use parseLocalDate to avoid timezone issues
         const dateOnlyPattern = /^\d{4}-\d{2}-\d{2}$/
-        // Match YYYY-MM-DD HH:mm or YYYY-MM-DD HH:mm:ss (with space or 'T' separator)
-        const dateTimePattern = /^\d{4}-\d{2}-\d{2}[T\s]\d{1,2}:\d{2}(:\d{2})?$/
+        // Match YYYY-MM-DD HH:mm or YYYY-MM-DD HH:mm:ss (with space or 'T' separator),
+        // with an optional trailing AM/PM for 12-hour display input
+        const dateTimePattern =
+            /^\d{4}-\d{2}-\d{2}[T\s]\d{1,2}:\d{2}(:\d{2})?(\s*(AM|PM))?$/i
         let date: Date
 
         if (dateOnlyPattern.test(trimmed)) {
             // Use parseLocalDate for YYYY-MM-DD to avoid timezone issues
             date = this.parseLocalDate(trimmed)
         } else if (this.enableTime && dateTimePattern.test(trimmed)) {
+            // Extract optional AM/PM suffix
+            const amPmMatch = trimmed.match(/\s*(AM|PM)$/i)
+            const amPm = amPmMatch
+                ? (amPmMatch[1].toUpperCase() as 'AM' | 'PM')
+                : null
+            const withoutAmPm = amPm
+                ? trimmed.slice(0, -amPmMatch![0].length).trim()
+                : trimmed
             // For date-time format when time is enabled, parse as UTC to match min/max dates from API
-            const [datePart, timePart] = trimmed.split(/[T\s]+/)
+            const [datePart, timePart] = withoutAmPm.split(/[T\s]+/)
             const [year, month, day] = datePart.split('-').map(Number)
             const timeComponents = timePart.split(':').map(Number)
-            const hours = timeComponents[0] || 0
+            let hours = timeComponents[0] || 0
             const minutes = timeComponents[1] || 0
             const seconds = timeComponents[2] || 0
+            // Convert 12-hour input to 24-hour display time
+            if (amPm) {
+                hours = this.to24Hour(hours, amPm)
+            }
             date = new Date(
                 Date.UTC(year, month - 1, day, hours, minutes, seconds),
             )
@@ -820,10 +983,23 @@ export default class TerraDatePicker extends TerraElement {
             let end: Date
 
             if (this.enableTime && startFormatted.length > 10) {
-                // Full datetime entered for start - parse it and extract time
-                // Normalize separator to T and append 'Z' to force UTC parsing
-                start = new Date(startFormatted.replace(' ', 'T') + 'Z')
-                this.initializeTimeFromDate(start, true)
+                // Full datetime entered for start - treat time as display timezone
+                const [sdp, stp] = startFormatted.split(/[T\s]+/)
+                const [sy, sm, sd] = sdp.split('-').map(Number)
+                const stc = stp.split(':').map(Number)
+                const sRefDate = new Date(Date.UTC(sy, sm - 1, sd))
+                const sUtc = this.getUtcTimeFromDisplay(
+                    stc[0] || 0,
+                    stc[1] || 0,
+                    stc[2] || 0,
+                    sRefDate,
+                )
+                start = new Date(
+                    Date.UTC(sy, sm - 1, sd, sUtc.hour, sUtc.minute, sUtc.second),
+                )
+                this.startHour = sUtc.hour
+                this.startMinute = sUtc.minute
+                this.startSecond = sUtc.second
             } else if (this.enableTime) {
                 // Date-only entered for start when time is enabled - parse date as UTC and apply current time picker values
                 const [year, month, day] = startFormatted.split('-').map(Number)
@@ -842,10 +1018,23 @@ export default class TerraDatePicker extends TerraElement {
             }
 
             if (this.enableTime && endFormatted.length > 10) {
-                // Full datetime entered for end - parse it and extract time
-                // Normalize separator to T and append 'Z' to force UTC parsing
-                end = new Date(endFormatted.replace(' ', 'T') + 'Z')
-                this.initializeTimeFromDate(end, false)
+                // Full datetime entered for end - treat time as display timezone
+                const [edp, etp] = endFormatted.split(/[T\s]+/)
+                const [ey, em, ed] = edp.split('-').map(Number)
+                const etc = etp.split(':').map(Number)
+                const eRefDate = new Date(Date.UTC(ey, em - 1, ed))
+                const eUtc = this.getUtcTimeFromDisplay(
+                    etc[0] || 0,
+                    etc[1] || 0,
+                    etc[2] || 0,
+                    eRefDate,
+                )
+                end = new Date(
+                    Date.UTC(ey, em - 1, ed, eUtc.hour, eUtc.minute, eUtc.second),
+                )
+                this.endHour = eUtc.hour
+                this.endMinute = eUtc.minute
+                this.endSecond = eUtc.second
             } else if (this.enableTime) {
                 // Date-only entered for end when time is enabled - parse date as UTC and apply current time picker values
                 const [year, month, day] = endFormatted.split('-').map(Number)
@@ -892,7 +1081,7 @@ export default class TerraDatePicker extends TerraElement {
             this.selectedStart = finalStart
             this.selectedEnd = finalEnd
             this.updateMonthViews()
-            input.value = `${startFormatted} – ${endFormatted}`
+            input.value = `${this.formatDisplayDate(finalStart, true)} – ${this.formatDisplayDate(finalEnd, false)}`
             input.setCustomValidity('')
             this.emitChange()
         } else {
@@ -906,10 +1095,23 @@ export default class TerraDatePicker extends TerraElement {
             // When time is enabled, parse as full UTC date; otherwise just date portion
             let date: Date
             if (this.enableTime && formatted.length > 10) {
-                // Full datetime entered - parse it and extract time
-                // Normalize separator to T and append 'Z' to force UTC parsing
-                date = new Date(formatted.replace(' ', 'T') + 'Z')
-                this.initializeTimeFromDate(date, true)
+                // Full datetime entered - treat time as display timezone, convert to UTC
+                const [dp, tp] = formatted.split(/[T\s]+/)
+                const [y, mo, d] = dp.split('-').map(Number)
+                const tc = tp.split(':').map(Number)
+                const refDate = new Date(Date.UTC(y, mo - 1, d))
+                const utc = this.getUtcTimeFromDisplay(
+                    tc[0] || 0,
+                    tc[1] || 0,
+                    tc[2] || 0,
+                    refDate,
+                )
+                date = new Date(
+                    Date.UTC(y, mo - 1, d, utc.hour, utc.minute, utc.second),
+                )
+                this.startHour = utc.hour
+                this.startMinute = utc.minute
+                this.startSecond = utc.second
             } else if (this.enableTime) {
                 // Date-only entered when time is enabled - parse date as UTC and apply current time picker values
                 const [year, month, day] = formatted.split('-').map(Number)
@@ -949,7 +1151,7 @@ export default class TerraDatePicker extends TerraElement {
             this.selectedStart = date
             this.selectedEnd = null
             this.updateMonthViews()
-            input.value = formatted
+            input.value = this.formatDisplayDate(date, true)
             input.setCustomValidity('')
             this.emitChange()
         }
@@ -976,10 +1178,23 @@ export default class TerraDatePicker extends TerraElement {
         // When time is enabled, parse as full UTC date; otherwise just date portion
         let date: Date
         if (this.enableTime && formatted.length > 10) {
-            // Full datetime entered - parse it and extract time
-            // Normalize separator to T and append 'Z' to force UTC parsing
-            date = new Date(formatted.replace(' ', 'T') + 'Z')
-            this.initializeTimeFromDate(date, true)
+            // Full datetime entered - treat time as display timezone, convert to UTC
+            const [dp, tp] = formatted.split(/[T\s]+/)
+            const [y, mo, d] = dp.split('-').map(Number)
+            const tc = tp.split(':').map(Number)
+            const refDate = new Date(Date.UTC(y, mo - 1, d))
+            const utc = this.getUtcTimeFromDisplay(
+                tc[0] || 0,
+                tc[1] || 0,
+                tc[2] || 0,
+                refDate,
+            )
+            date = new Date(
+                Date.UTC(y, mo - 1, d, utc.hour, utc.minute, utc.second),
+            )
+            this.startHour = utc.hour
+            this.startMinute = utc.minute
+            this.startSecond = utc.second
         } else if (this.enableTime) {
             // Date-only entered when time is enabled - parse date as UTC and apply current time picker values
             const [year, month, day] = formatted.split('-').map(Number)
@@ -1025,7 +1240,7 @@ export default class TerraDatePicker extends TerraElement {
 
         this.selectedStart = date
         this.leftMonth = new Date(date)
-        input.value = formatted
+        input.value = this.formatDisplayDate(date, true)
         input.setCustomValidity('')
         this.emitChange()
     }
@@ -1051,10 +1266,23 @@ export default class TerraDatePicker extends TerraElement {
         // When time is enabled, parse as full UTC date; otherwise just date portion
         let date: Date
         if (this.enableTime && formatted.length > 10) {
-            // Full datetime entered - parse it and extract time
-            // Normalize separator to T and append 'Z' to force UTC parsing
-            date = new Date(formatted.replace(' ', 'T') + 'Z')
-            this.initializeTimeFromDate(date, false)
+            // Full datetime entered - treat time as display timezone, convert to UTC
+            const [dp, tp] = formatted.split(/[T\s]+/)
+            const [y, mo, d] = dp.split('-').map(Number)
+            const tc = tp.split(':').map(Number)
+            const refDate = new Date(Date.UTC(y, mo - 1, d))
+            const utc = this.getUtcTimeFromDisplay(
+                tc[0] || 0,
+                tc[1] || 0,
+                tc[2] || 0,
+                refDate,
+            )
+            date = new Date(
+                Date.UTC(y, mo - 1, d, utc.hour, utc.minute, utc.second),
+            )
+            this.endHour = utc.hour
+            this.endMinute = utc.minute
+            this.endSecond = utc.second
         } else if (this.enableTime) {
             // Date-only entered when time is enabled - parse date as UTC and apply current time picker values
             const [year, month, day] = formatted.split('-').map(Number)
@@ -1125,6 +1353,7 @@ export default class TerraDatePicker extends TerraElement {
         } else {
             this.rightMonth = new Date(date)
         }
+        input.value = this.formatDisplayDate(date, false)
         input.setCustomValidity('')
         this.emitChange()
     }
@@ -1576,42 +1805,45 @@ export default class TerraDatePicker extends TerraElement {
         delta: number,
         isStart: boolean,
     ) {
+        const utcH = isStart ? this.startHour : this.endHour
+        const utcM = isStart ? this.startMinute : this.endMinute
+        const utcS = isStart ? this.startSecond : this.endSecond
+        const ref = isStart ? this.selectedStart : this.selectedEnd
+        const display = this.getDisplayTimeComponents(utcH, utcM, utcS, ref)
+
+        let newDisplayH = display.hour
+        let newDisplayM = display.minute
+        let newDisplayS = display.second
+
         if (type === 'hour') {
-            if (isStart) {
-                let newHour = this.startHour + delta
-                if (newHour > 23) newHour = 0
-                if (newHour < 0) newHour = 23
-                this.startHour = newHour
+            if (this.twelveHour) {
+                // Spin within 1–12, preserving the current AM/PM period
+                const d12 = this.to12Hour(display.hour)
+                const newHour12 = ((d12.hour - 1 + delta) % 12 + 12) % 12 + 1
+                newDisplayH = this.to24Hour(newHour12, d12.period)
             } else {
-                let newHour = this.endHour + delta
-                if (newHour > 23) newHour = 0
-                if (newHour < 0) newHour = 23
-                this.endHour = newHour
+                newDisplayH = ((display.hour + delta) % 24 + 24) % 24
             }
         } else if (type === 'minute') {
-            if (isStart) {
-                let newMinute = this.startMinute + delta
-                if (newMinute >= 60) newMinute = 0
-                if (newMinute < 0) newMinute = 59
-                this.startMinute = newMinute
-            } else {
-                let newMinute = this.endMinute + delta
-                if (newMinute >= 60) newMinute = 0
-                if (newMinute < 0) newMinute = 59
-                this.endMinute = newMinute
-            }
+            newDisplayM = ((display.minute + delta) % 60 + 60) % 60
         } else {
-            if (isStart) {
-                let newSecond = this.startSecond + delta
-                if (newSecond >= 60) newSecond = 0
-                if (newSecond < 0) newSecond = 59
-                this.startSecond = newSecond
-            } else {
-                let newSecond = this.endSecond + delta
-                if (newSecond >= 60) newSecond = 0
-                if (newSecond < 0) newSecond = 59
-                this.endSecond = newSecond
-            }
+            newDisplayS = ((display.second + delta) % 60 + 60) % 60
+        }
+
+        const utc = this.getUtcTimeFromDisplay(
+            newDisplayH,
+            newDisplayM,
+            newDisplayS,
+            ref,
+        )
+        if (isStart) {
+            this.startHour = utc.hour
+            this.startMinute = utc.minute
+            this.startSecond = utc.second
+        } else {
+            this.endHour = utc.hour
+            this.endMinute = utc.minute
+            this.endSecond = utc.second
         }
         this.emitChange()
         this.requestUpdate()
@@ -1623,35 +1855,59 @@ export default class TerraDatePicker extends TerraElement {
         isStart: boolean,
     ) {
         const input = event.target as HTMLInputElement
-        let value = parseInt(input.value, 10)
+        const value = parseInt(input.value, 10)
+
+        const utcH = isStart ? this.startHour : this.endHour
+        const utcM = isStart ? this.startMinute : this.endMinute
+        const utcS = isStart ? this.startSecond : this.endSecond
+        const ref = isStart ? this.selectedStart : this.selectedEnd
+        const display = this.getDisplayTimeComponents(utcH, utcM, utcS, ref)
+        const d12 = this.twelveHour ? this.to12Hour(display.hour) : null
+
+        let newDisplayH = display.hour
+        let newDisplayM = display.minute
+        let newDisplayS = display.second
 
         if (type === 'hour') {
-            if (isNaN(value) || value < 0 || value > 23) {
-                input.value = isStart
-                    ? this.startHour.toString().padStart(2, '0')
-                    : this.endHour.toString().padStart(2, '0')
+            const min = this.twelveHour ? 1 : 0
+            const max = this.twelveHour ? 12 : 23
+            if (isNaN(value) || value < min || value > max) {
+                input.value = (d12 ? d12.hour : display.hour)
+                    .toString()
+                    .padStart(2, '0')
                 return
             }
-            if (isStart) this.startHour = value
-            else this.endHour = value
+            newDisplayH = this.twelveHour
+                ? this.to24Hour(value, d12!.period)
+                : value
         } else if (type === 'minute') {
             if (isNaN(value) || value < 0 || value >= 60) {
-                input.value = isStart
-                    ? this.startMinute.toString().padStart(2, '0')
-                    : this.endMinute.toString().padStart(2, '0')
+                input.value = display.minute.toString().padStart(2, '0')
                 return
             }
-            if (isStart) this.startMinute = value
-            else this.endMinute = value
+            newDisplayM = value
         } else {
             if (isNaN(value) || value < 0 || value >= 60) {
-                input.value = isStart
-                    ? this.startSecond.toString().padStart(2, '0')
-                    : this.endSecond.toString().padStart(2, '0')
+                input.value = display.second.toString().padStart(2, '0')
                 return
             }
-            if (isStart) this.startSecond = value
-            else this.endSecond = value
+            newDisplayS = value
+        }
+
+        const utc = this.getUtcTimeFromDisplay(
+            newDisplayH,
+            newDisplayM,
+            newDisplayS,
+            ref,
+        )
+        if (isStart) {
+            this.startHour = utc.hour
+            this.startMinute = utc.minute
+            this.startSecond = utc.second
+        } else {
+            this.endHour = utc.hour
+            this.endMinute = utc.minute
+            this.endSecond = utc.second
         }
         this.emitChange()
         this.requestUpdate()
@@ -1896,6 +2152,23 @@ export default class TerraDatePicker extends TerraElement {
     private renderTimePicker() {
         if (!this.enableTime) return ''
 
+        const startDisplay = this.getDisplayTimeComponents(
+            this.startHour,
+            this.startMinute,
+            this.startSecond,
+            this.selectedStart,
+        )
+        const endDisplay = this.getDisplayTimeComponents(
+            this.endHour,
+            this.endMinute,
+            this.endSecond,
+            this.selectedEnd,
+        )
+        const startD12 = this.twelveHour ? this.to12Hour(startDisplay.hour) : null
+        const endD12 = this.twelveHour ? this.to12Hour(endDisplay.hour) : null
+        const hourMin = this.twelveHour ? '1' : '0'
+        const hourMax = this.twelveHour ? '12' : '23'
+
         return html`
             <div class="date-picker__time">
                 <div class="date-picker__time-section">
@@ -1904,17 +2177,31 @@ export default class TerraDatePicker extends TerraElement {
                             <input
                                 type="number"
                                 class="date-picker__time-input"
-                                .value=${this.startHour.toString().padStart(2, '0')}
+                                .value=${(startD12
+                                    ? startD12.hour
+                                    : startDisplay.hour
+                                )
+                                    .toString()
+                                    .padStart(2, '0')}
                                 @input=${(e: Event) =>
                                     this.handleTimeInput(e, 'hour', true)}
                                 @blur=${(e: Event) => {
                                     const input = e.target as HTMLInputElement
-                                    input.value = this.startHour
+                                    const d = this.getDisplayTimeComponents(
+                                        this.startHour,
+                                        this.startMinute,
+                                        this.startSecond,
+                                        this.selectedStart,
+                                    )
+                                    const d12 = this.twelveHour
+                                        ? this.to12Hour(d.hour)
+                                        : null
+                                    input.value = (d12 ? d12.hour : d.hour)
                                         .toString()
                                         .padStart(2, '0')
                                 }}
-                                min="0"
-                                max="23"
+                                min=${hourMin}
+                                max=${hourMax}
                             />
                             <div class="date-picker__time-spinners">
                                 <button
@@ -1966,12 +2253,20 @@ export default class TerraDatePicker extends TerraElement {
                             <input
                                 type="number"
                                 class="date-picker__time-input"
-                                .value=${this.startMinute.toString().padStart(2, '0')}
+                                .value=${startDisplay.minute
+                                    .toString()
+                                    .padStart(2, '0')}
                                 @input=${(e: Event) =>
                                     this.handleTimeInput(e, 'minute', true)}
                                 @blur=${(e: Event) => {
                                     const input = e.target as HTMLInputElement
-                                    input.value = this.startMinute
+                                    const d = this.getDisplayTimeComponents(
+                                        this.startHour,
+                                        this.startMinute,
+                                        this.startSecond,
+                                        this.selectedStart,
+                                    )
+                                    input.value = d.minute
                                         .toString()
                                         .padStart(2, '0')
                                 }}
@@ -2029,12 +2324,20 @@ export default class TerraDatePicker extends TerraElement {
                             <input
                                 type="number"
                                 class="date-picker__time-input"
-                                .value=${this.startSecond.toString().padStart(2, '0')}
+                                .value=${startDisplay.second
+                                    .toString()
+                                    .padStart(2, '0')}
                                 @input=${(e: Event) =>
                                     this.handleTimeInput(e, 'second', true)}
                                 @blur=${(e: Event) => {
                                     const input = e.target as HTMLInputElement
-                                    input.value = this.startSecond
+                                    const d = this.getDisplayTimeComponents(
+                                        this.startHour,
+                                        this.startMinute,
+                                        this.startSecond,
+                                        this.selectedStart,
+                                    )
+                                    input.value = d.second
                                         .toString()
                                         .padStart(2, '0')
                                 }}
@@ -2085,6 +2388,20 @@ export default class TerraDatePicker extends TerraElement {
                                 </button>
                             </div>
                         </div>
+
+                        ${
+                            this.twelveHour
+                                ? html`
+                                  <button
+                                      type="button"
+                                      class="date-picker__time-period"
+                                      @click=${() => this.togglePeriod(true)}
+                                  >
+                                      ${startD12!.period}
+                                  </button>
+                              `
+                                : ''
+                        }
                     </div>
                 </div>
 
@@ -2099,7 +2416,10 @@ export default class TerraDatePicker extends TerraElement {
                                       <input
                                           type="number"
                                           class="date-picker__time-input"
-                                          .value=${this.endHour
+                                          .value=${(endD12
+                                              ? endD12.hour
+                                              : endDisplay.hour
+                                          )
                                               .toString()
                                               .padStart(2, '0')}
                                           @input=${(e: Event) =>
@@ -2111,12 +2431,24 @@ export default class TerraDatePicker extends TerraElement {
                                           @blur=${(e: Event) => {
                                               const input =
                                                   e.target as HTMLInputElement
-                                              input.value = this.endHour
+                                              const d =
+                                                  this.getDisplayTimeComponents(
+                                                      this.endHour,
+                                                      this.endMinute,
+                                                      this.endSecond,
+                                                      this.selectedEnd,
+                                                  )
+                                              const d12 = this.twelveHour
+                                                  ? this.to12Hour(d.hour)
+                                                  : null
+                                              input.value = (
+                                                  d12 ? d12.hour : d.hour
+                                              )
                                                   .toString()
                                                   .padStart(2, '0')
                                           }}
-                                          min="0"
-                                          max="23"
+                                          min=${hourMin}
+                                          max=${hourMax}
                                       />
                                       <div class="date-picker__time-spinners">
                                           <button
@@ -2178,7 +2510,7 @@ export default class TerraDatePicker extends TerraElement {
                                       <input
                                           type="number"
                                           class="date-picker__time-input"
-                                          .value=${this.endMinute
+                                          .value=${endDisplay.minute
                                               .toString()
                                               .padStart(2, '0')}
                                           @input=${(e: Event) =>
@@ -2190,7 +2522,14 @@ export default class TerraDatePicker extends TerraElement {
                                           @blur=${(e: Event) => {
                                               const input =
                                                   e.target as HTMLInputElement
-                                              input.value = this.endMinute
+                                              const d =
+                                                  this.getDisplayTimeComponents(
+                                                      this.endHour,
+                                                      this.endMinute,
+                                                      this.endSecond,
+                                                      this.selectedEnd,
+                                                  )
+                                              input.value = d.minute
                                                   .toString()
                                                   .padStart(2, '0')
                                           }}
@@ -2257,7 +2596,7 @@ export default class TerraDatePicker extends TerraElement {
                                       <input
                                           type="number"
                                           class="date-picker__time-input"
-                                          .value=${this.endSecond
+                                          .value=${endDisplay.second
                                               .toString()
                                               .padStart(2, '0')}
                                           @input=${(e: Event) =>
@@ -2269,7 +2608,14 @@ export default class TerraDatePicker extends TerraElement {
                                           @blur=${(e: Event) => {
                                               const input =
                                                   e.target as HTMLInputElement
-                                              input.value = this.endSecond
+                                              const d =
+                                                  this.getDisplayTimeComponents(
+                                                      this.endHour,
+                                                      this.endMinute,
+                                                      this.endSecond,
+                                                      this.selectedEnd,
+                                                  )
+                                              input.value = d.second
                                                   .toString()
                                                   .padStart(2, '0')
                                           }}
@@ -2330,6 +2676,21 @@ export default class TerraDatePicker extends TerraElement {
                                       </div>
                                   </div>
                               </div>
+
+                                  ${
+                                      this.twelveHour
+                                          ? html`
+                                            <button
+                                                type="button"
+                                                class="date-picker__time-period"
+                                                @click=${() =>
+                                                    this.togglePeriod(false)}
+                                            >
+                                                ${endD12!.period}
+                                            </button>
+                                        `
+                                          : ''
+                                  }
                           </div>
                       `
                         : ''

--- a/src/components/date-picker/date-picker.test.ts
+++ b/src/components/date-picker/date-picker.test.ts
@@ -1992,4 +1992,235 @@ describe('<terra-date-picker>', () => {
             })
         })
     })
+
+    describe('Timezone Display', () => {
+        it('should accept timezone property', async () => {
+            const el: TerraDatePicker = await fixture(html`
+                <terra-date-picker
+                    timezone="America/New_York"
+                ></terra-date-picker>
+            `)
+            expect((el as any).timezone).to.equal('America/New_York')
+        })
+
+        it('should not break with an invalid timezone string', async () => {
+            const el: TerraDatePicker = await fixture(html`
+                <terra-date-picker
+                    enable-time
+                    timezone="Not/AValid/Timezone"
+                    start-date="2024-03-20T15:00:00Z"
+                ></terra-date-picker>
+            `)
+            await elementUpdated(el)
+            // Component should still render; offset falls back to 0
+            expect(el).to.exist
+        })
+
+        it('should shift displayed time by timezone offset', async () => {
+            // UTC 15:00 → America/New_York EST = UTC-5 → 10:00
+            const el: TerraDatePicker = await fixture(html`
+                <terra-date-picker
+                    enable-time
+                    timezone="America/New_York"
+                    start-date="2024-01-20T15:00:00Z"
+                ></terra-date-picker>
+            `)
+            await elementUpdated(el)
+            const displayDate = (el as any).formatDisplayDate(
+                new Date('2024-01-20T15:00:00Z'),
+                true,
+            ) as string
+            // UTC 15:00 minus 5h = display 10:00 for EST
+            expect(displayDate).to.include('10:00:00')
+        })
+
+        it('should emit UTC value unchanged regardless of timezone', async () => {
+            const el: TerraDatePicker = await fixture(html`
+                <terra-date-picker
+                    enable-time
+                    timezone="America/New_York"
+                    start-date="2024-01-20T15:00:00Z"
+                ></terra-date-picker>
+            `)
+            await elementUpdated(el)
+
+            const listener = oneEvent(el, 'terra-date-range-change')
+            ;(el as any).emitChange()
+            const { detail } = await listener
+            // Emitted ISO string should be UTC (ends with Z)
+            expect(detail.startDate).to.match(/Z$/)
+        })
+    })
+
+    describe('12-Hour Format', () => {
+        it('should accept twelve-hour attribute', async () => {
+            const el: TerraDatePicker = await fixture(html`
+                <terra-date-picker enable-time twelve-hour></terra-date-picker>
+            `)
+            expect((el as any).twelveHour).to.be.true
+        })
+
+        it('should default twelveHour to false', async () => {
+            const el: TerraDatePicker = await fixture(html`
+                <terra-date-picker enable-time></terra-date-picker>
+            `)
+            expect((el as any).twelveHour).to.be.false
+        })
+
+        it('should display AM period for hours 0-11', async () => {
+            const el: TerraDatePicker = await fixture(html`
+                <terra-date-picker
+                    enable-time
+                    twelve-hour
+                    start-date="2024-03-20T09:30:00Z"
+                ></terra-date-picker>
+            `)
+            await elementUpdated(el)
+            const displayDate = (el as any).formatDisplayDate(
+                new Date('2024-03-20T09:30:00Z'),
+                true,
+            ) as string
+            expect(displayDate).to.include('AM')
+            expect(displayDate).to.include('09:30:00')
+        })
+
+        it('should display PM period for hours 12-23', async () => {
+            const el: TerraDatePicker = await fixture(html`
+                <terra-date-picker
+                    enable-time
+                    twelve-hour
+                    start-date="2024-03-20T15:30:00Z"
+                ></terra-date-picker>
+            `)
+            await elementUpdated(el)
+            const displayDate = (el as any).formatDisplayDate(
+                new Date('2024-03-20T15:30:00Z'),
+                true,
+            ) as string
+            expect(displayDate).to.include('PM')
+            // 15:00 UTC → 03:30:00 in 12h display
+            expect(displayDate).to.include('03:30:00')
+        })
+
+        it('to12Hour converts midnight (0) to 12 AM', async () => {
+            const el: TerraDatePicker = await fixture(html`
+                <terra-date-picker enable-time twelve-hour></terra-date-picker>
+            `)
+            const result = (el as any).to12Hour(0)
+            expect(result.hour).to.equal(12)
+            expect(result.period).to.equal('AM')
+        })
+
+        it('to12Hour converts noon (12) to 12 PM', async () => {
+            const el: TerraDatePicker = await fixture(html`
+                <terra-date-picker enable-time twelve-hour></terra-date-picker>
+            `)
+            const result = (el as any).to12Hour(12)
+            expect(result.hour).to.equal(12)
+            expect(result.period).to.equal('PM')
+        })
+
+        it('to24Hour converts 12 AM to 0', async () => {
+            const el: TerraDatePicker = await fixture(html`
+                <terra-date-picker enable-time twelve-hour></terra-date-picker>
+            `)
+            expect((el as any).to24Hour(12, 'AM')).to.equal(0)
+        })
+
+        it('to24Hour converts 12 PM to 12', async () => {
+            const el: TerraDatePicker = await fixture(html`
+                <terra-date-picker enable-time twelve-hour></terra-date-picker>
+            `)
+            expect((el as any).to24Hour(12, 'PM')).to.equal(12)
+        })
+
+        it('togglePeriod flips start AM to PM and keeps UTC correct', async () => {
+            // UTC 09:00 → AM in 12h; toggle → PM → UTC 21:00
+            const el: TerraDatePicker = await fixture(html`
+                <terra-date-picker
+                    enable-time
+                    twelve-hour
+                    start-date="2024-03-20T09:00:00Z"
+                ></terra-date-picker>
+            `)
+            await elementUpdated(el)
+            ;(el as any).togglePeriod(true)
+            await elementUpdated(el)
+            expect((el as any).startHour).to.equal(21)
+        })
+
+        it('AM/PM button renders in time picker when twelve-hour is set', async () => {
+            const el: TerraDatePicker = await fixture(html`
+                <terra-date-picker enable-time twelve-hour></terra-date-picker>
+            `)
+            await elementUpdated(el)
+            // Open the picker
+            const trigger = el.shadowRoot?.querySelector<HTMLElement>(
+                '.date-picker__trigger',
+            )
+            trigger?.click()
+            await elementUpdated(el)
+            const periodBtn = el.shadowRoot?.querySelector(
+                '.date-picker__time-period',
+            )
+            expect(periodBtn).to.exist
+        })
+
+        it('emits UTC 24h value when twelve-hour mode is active', async () => {
+            // UTC 15:00 = 3 PM in 12h; emitted startDate should be UTC ISO with hour 15
+            const el: TerraDatePicker = await fixture(html`
+                <terra-date-picker
+                    enable-time
+                    twelve-hour
+                    start-date="2024-03-20T15:00:00Z"
+                ></terra-date-picker>
+            `)
+            await elementUpdated(el)
+
+            const listener = oneEvent(el, 'terra-date-range-change')
+            ;(el as any).emitChange()
+            const { detail } = await listener
+            expect(detail.startDate).to.match(/T15:00:00\.000Z$/)
+        })
+    })
+
+    describe('Timezone + 12-Hour Combined', () => {
+        it('should apply timezone offset then format as 12h', async () => {
+            // UTC 00:30 → America/New_York EST = UTC-5 → 19:30 prev day (but same Date used)
+            // UTC 15:30 → EST = 10:30 AM
+            const el: TerraDatePicker = await fixture(html`
+                <terra-date-picker
+                    enable-time
+                    timezone="America/New_York"
+                    twelve-hour
+                    start-date="2024-01-20T15:30:00Z"
+                ></terra-date-picker>
+            `)
+            await elementUpdated(el)
+            const displayDate = (el as any).formatDisplayDate(
+                new Date('2024-01-20T15:30:00Z'),
+                true,
+            ) as string
+            // UTC 15:30 minus 5h (EST) = 10:30 → 10:30:00 AM
+            expect(displayDate).to.include('10:30:00')
+            expect(displayDate).to.include('AM')
+        })
+
+        it('emits UTC regardless of timezone + twelve-hour combination', async () => {
+            const el: TerraDatePicker = await fixture(html`
+                <terra-date-picker
+                    enable-time
+                    timezone="America/New_York"
+                    twelve-hour
+                    start-date="2024-01-20T15:30:00Z"
+                ></terra-date-picker>
+            `)
+            await elementUpdated(el)
+
+            const listener = oneEvent(el, 'terra-date-range-change')
+            ;(el as any).emitChange()
+            const { detail } = await listener
+            expect(detail.startDate).to.match(/T15:30:00\.000Z$/)
+        })
+    })
 })

--- a/src/components/date-range-slider/date-range-slider.component.ts
+++ b/src/components/date-range-slider/date-range-slider.component.ts
@@ -10,9 +10,8 @@ import noUiSlider, {
     type Options,
     type Formatter,
 } from 'nouislider'
-import { format } from 'date-fns'
 import { mergeTooltips } from './noui-slider-utilities.js'
-import { isValidDate } from '../../utilities/date.js'
+import { formatDate, isValidDate } from '../../utilities/date.js'
 import { watch } from '../../internal/watch.js'
 
 export type TimeScale = 'half-hourly' | 'hourly' | 'daily'
@@ -104,10 +103,10 @@ export default class TerraDateRangeSlider extends TerraElement {
         const minDate = new Date(this.minDate)
         const maxDate = new Date(this.maxDate)
         const startDate = new Date(
-            isValidDate(this.startDate) ? this.startDate : this.minDate
+            isValidDate(this.startDate) ? this.startDate : this.minDate,
         )
         const endDate = new Date(
-            isValidDate(this.endDate) ? this.endDate : this.maxDate
+            isValidDate(this.endDate) ? this.endDate : this.maxDate,
         )
 
         // adjust dates to be beginning and end of the day
@@ -141,7 +140,7 @@ export default class TerraDateRangeSlider extends TerraElement {
 
         mergeTooltips(this.slider)
 
-        this.slider.noUiSlider.on('change', (values: any) => {
+        this.slider.noUiSlider.on('change', (values: (string | number)[]) => {
             this.emit('terra-date-range-change', {
                 detail: {
                     startDate: this._formatDate(values[0]),
@@ -193,7 +192,7 @@ export default class TerraDateRangeSlider extends TerraElement {
     private _formatDate(date: string | number | Date) {
         const dateFormat =
             this.timeScale === 'daily' ? 'yyyy-MM-dd' : 'yyyy-MM-dd HH:mm'
-        return format(new Date(date).toUTCString(), dateFormat)
+        return formatDate(new Date(date), dateFormat)
     }
 
     render() {

--- a/src/components/map/map.service.ts
+++ b/src/components/map/map.service.ts
@@ -169,12 +169,12 @@ export class MapService {
             })
 
             // Emit the shape as a polygon draw event so listeners can react
-            // Note: if MapEventDetail is extended to include a geoJson field in future,
-            // pass shapeGeoJson here so consumers (e.g. data-access) can use it for bbox extraction
             this.#onDraw?.({
                 cause: 'draw',
                 type: MapEventType.POLYGON,
                 latLngs: [],
+                geoJson: shapeGeoJson as object,
+                label: select.options[select.selectedIndex]?.text,
             })
         } finally {
             this.#onShapeLoading?.(false)

--- a/src/components/map/type.ts
+++ b/src/components/map/type.ts
@@ -16,7 +16,12 @@ export type MapEventDetail = BaseMapEventDetail &
     (
         | { type: MapEventType.POINT; latLng: LatLng }
         | { type: MapEventType.BBOX; bounds: LatLngBounds }
-        | { type: MapEventType.POLYGON; latLngs: LatLng[] }
+        | {
+              type: MapEventType.POLYGON
+              latLngs: LatLng[]
+              geoJson?: object
+              label?: string
+          }
         | { type: MapEventType.CIRCLE; center: LatLng; radius: number }
         | { type?: undefined }
     )

--- a/src/components/plot-toolbar/notebooks/time-averaged-map-notebook.ts
+++ b/src/components/plot-toolbar/notebooks/time-averaged-map-notebook.ts
@@ -21,7 +21,7 @@ export function getTimeAveragedMapNotebook(host: TerraPlotToolbar) {
         {
             id: '2733501b-0de4-4067-8aff-864e1b4c76cb',
             cell_type: 'code',
-            source: '%pip install -q "terra_ui_components==0.0.191" "anywidget==0.9.15" "pandas" "rasterio" "matplotlib"',
+            source: '%pip install -q "terra_ui_components==0.0.192" "anywidget==0.9.15" "pandas" "rasterio" "matplotlib"',
             metadata: {
                 trusted: true,
             },

--- a/src/components/plot-toolbar/notebooks/time-averaged-map-notebook.ts
+++ b/src/components/plot-toolbar/notebooks/time-averaged-map-notebook.ts
@@ -21,7 +21,7 @@ export function getTimeAveragedMapNotebook(host: TerraPlotToolbar) {
         {
             id: '2733501b-0de4-4067-8aff-864e1b4c76cb',
             cell_type: 'code',
-            source: '%pip install -q "terra_ui_components==0.0.193" "anywidget==0.9.15" "pandas" "rasterio" "matplotlib"',
+            source: '%pip install -q "terra_ui_components==0.0.194" "anywidget==0.9.15" "pandas" "rasterio" "matplotlib"',
             metadata: {
                 trusted: true,
             },

--- a/src/components/plot-toolbar/notebooks/time-averaged-map-notebook.ts
+++ b/src/components/plot-toolbar/notebooks/time-averaged-map-notebook.ts
@@ -21,7 +21,7 @@ export function getTimeAveragedMapNotebook(host: TerraPlotToolbar) {
         {
             id: '2733501b-0de4-4067-8aff-864e1b4c76cb',
             cell_type: 'code',
-            source: '%pip install -q "terra_ui_components==0.0.192" "anywidget==0.9.15" "pandas" "rasterio" "matplotlib"',
+            source: '%pip install -q "terra_ui_components==0.0.193" "anywidget==0.9.15" "pandas" "rasterio" "matplotlib"',
             metadata: {
                 trusted: true,
             },

--- a/src/components/plot-toolbar/notebooks/time-series-notebook.ts
+++ b/src/components/plot-toolbar/notebooks/time-series-notebook.ts
@@ -21,7 +21,7 @@ export function getTimeSeriesNotebook(host: TerraPlotToolbar) {
         {
             id: '2733501b-0de4-4067-8aff-864e1b4c76cb',
             cell_type: 'code',
-            source: '%pip install -q "terra_ui_components==0.0.192" "anywidget==0.9.15" "pandas"',
+            source: '%pip install -q "terra_ui_components==0.0.193" "anywidget==0.9.15" "pandas"',
             metadata: {
                 trusted: true,
             },

--- a/src/components/plot-toolbar/notebooks/time-series-notebook.ts
+++ b/src/components/plot-toolbar/notebooks/time-series-notebook.ts
@@ -21,7 +21,7 @@ export function getTimeSeriesNotebook(host: TerraPlotToolbar) {
         {
             id: '2733501b-0de4-4067-8aff-864e1b4c76cb',
             cell_type: 'code',
-            source: '%pip install -q "terra_ui_components==0.0.191" "anywidget==0.9.15" "pandas"',
+            source: '%pip install -q "terra_ui_components==0.0.192" "anywidget==0.9.15" "pandas"',
             metadata: {
                 trusted: true,
             },

--- a/src/components/plot-toolbar/notebooks/time-series-notebook.ts
+++ b/src/components/plot-toolbar/notebooks/time-series-notebook.ts
@@ -21,7 +21,7 @@ export function getTimeSeriesNotebook(host: TerraPlotToolbar) {
         {
             id: '2733501b-0de4-4067-8aff-864e1b4c76cb',
             cell_type: 'code',
-            source: '%pip install -q "terra_ui_components==0.0.193" "anywidget==0.9.15" "pandas"',
+            source: '%pip install -q "terra_ui_components==0.0.194" "anywidget==0.9.15" "pandas"',
             metadata: {
                 trusted: true,
             },

--- a/src/components/spatial-picker/spatial-picker.component.ts
+++ b/src/components/spatial-picker/spatial-picker.component.ts
@@ -46,6 +46,13 @@ export default class TerraSpatialPicker extends TerraElement {
     showBoundingBoxSelection: boolean = true
 
     /**
+     * Whether polygon selection is allowed via the draw toolbar.
+     * Mirrors the terra-map attribute name for consistency.
+     */
+    @property({ attribute: 'show-polygon-selection', type: Boolean })
+    showPolygonSelection: boolean = false
+
+    /**
      * @deprecated Use show-bounding-box-selection instead.
      */
     @property({ attribute: 'hide-bounding-box-selection', type: Boolean })
@@ -401,6 +408,7 @@ export default class TerraSpatialPicker extends TerraElement {
             ?has-navigation=${this.hasNavigation}
             ?has-shape-selector=${this.hasShapeSelector}
             ?show-bounding-box-selection=${this.showBoundingBoxSelection}
+            ?show-polygon-selection=${this.showPolygonSelection}
             ?show-point-selection=${this.showPointSelection}
             ?no-world-wrap=${!this.worldWrap}
             spatial-constraints=${this.spatialConstraints}

--- a/src/components/time-series/time-series-cache.service.test.ts
+++ b/src/components/time-series/time-series-cache.service.test.ts
@@ -65,14 +65,40 @@ describe('TimeSeriesCacheService', () => {
         const gaps = service.calculateDataGaps(start, end, existing)
 
         expect(gaps).to.have.length(2)
-        expect(gaps[0].start.toISOString()).to.equal(
-            '2024-01-01T00:00:00.000Z',
-        )
-        expect(gaps[0].end.toISOString()).to.equal('2024-01-03T00:00:00.000Z')
-        expect(gaps[1].start.toISOString()).to.equal(
-            '2024-01-10T00:00:00.000Z',
-        )
-        expect(gaps[1].end.toISOString()).to.equal('2024-01-12T00:00:00.000Z')
+        expect(gaps[0].start.toISOString()).to.equal('2024-01-01T00:00:00.000Z')
+        expect(gaps[0].end.toISOString()).to.equal('2024-01-02T23:59:59.999Z')
+        expect(gaps[1].start.toISOString()).to.equal('2024-01-11T00:00:00.000Z')
+        expect(gaps[1].end.toISOString()).to.equal('2024-01-12T23:59:59.999Z')
+    })
+
+    it('returns only a trailing gap when extending an already cached range', () => {
+        const start = new Date('2024-01-01T00:00:00.000Z')
+        const end = new Date('2024-01-12T00:00:00.000Z')
+
+        const existing = toEntry({
+            startDate: '2024-01-01T00:00:00.000Z',
+            endDate: '2024-01-10T23:59:59.999Z',
+        })
+
+        const gaps = service.calculateDataGaps(start, end, existing)
+
+        expect(gaps).to.have.length(1)
+        expect(gaps[0].start.toISOString()).to.equal('2024-01-11T00:00:00.000Z')
+        expect(gaps[0].end.toISOString()).to.equal('2024-01-12T23:59:59.999Z')
+    })
+
+    it('returns no gaps when requested range is covered within the same UTC days', () => {
+        const start = new Date('2024-01-01T12:00:00.000Z')
+        const end = new Date('2024-01-10T06:00:00.000Z')
+
+        const existing = toEntry({
+            startDate: '2024-01-01T00:00:00.000Z',
+            endDate: '2024-01-10T23:59:59.999Z',
+        })
+
+        const gaps = service.calculateDataGaps(start, end, existing)
+
+        expect(gaps).to.have.length(0)
     })
 
     it('deduplicates rows by timestamp while preserving first occurrence', () => {
@@ -113,7 +139,7 @@ describe('TimeSeriesCacheService', () => {
             new Date('2024-01-10T23:59:59.999Z'),
         )
 
-        expect(result.data.map(row => row.value)).to.deep.equal(['1', '2'])
+        expect(result.data.map((row) => row.value)).to.deep.equal(['1', '2'])
     })
 
     it('treats missing cachedAt as invalid cache', () => {

--- a/src/components/time-series/time-series-cache.service.ts
+++ b/src/components/time-series/time-series-cache.service.ts
@@ -120,10 +120,17 @@ export class TimeSeriesCacheService {
         environment?: string
         metadata: Partial<TimeSeriesMetadata>
         data: TimeSeriesDataRow[]
+        /** The originally-requested start date. When provided, the stored range covers at least
+         *  this date so that future requests for the same range don't detect a spurious gap
+         *  just because Harmony returned data starting later than the requested start. */
+        requestedStartDate?: Date
+        /** The originally-requested end date. Same rationale as requestedStartDate. */
+        requestedEndDate?: Date
     }): Promise<void> {
-        const { cacheKey, variableEntryId, environment, metadata, data } = options
+        const { cacheKey, variableEntryId, environment, metadata, data,
+                requestedStartDate, requestedEndDate } = options
 
-        if (!cacheKey || !data.length) {
+        if (!cacheKey) {
             return
         }
 
@@ -131,11 +138,25 @@ export class TimeSeriesCacheService {
             (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
         )
 
+        // Use the requested range as the stored range when it extends beyond the actual data.
+        // This prevents a cache-miss loop when the dataset simply has no data at the edges
+        // (e.g. requesting Jan 1 but the first available data point is Jan 15).
+        const storedStart = requestedStartDate && sortedData.length > 0
+            ? new Date(Math.min(requestedStartDate.getTime(), new Date(sortedData[0].timestamp).getTime())).toISOString()
+            : sortedData[0]?.timestamp
+        const storedEnd = requestedEndDate && sortedData.length > 0
+            ? new Date(Math.max(requestedEndDate.getTime(), new Date(sortedData[sortedData.length - 1].timestamp).getTime())).toISOString()
+            : sortedData[sortedData.length - 1]?.timestamp
+
+        if (!storedStart || !storedEnd) {
+            return
+        }
+
         await storeDataByKey<VariableDbEntry>(IndexedDbStores.TIME_SERIES, cacheKey, {
             variableEntryId,
             key: cacheKey,
-            startDate: sortedData[0].timestamp,
-            endDate: sortedData[sortedData.length - 1].timestamp,
+            startDate: storedStart,
+            endDate: storedEnd,
             metadata: metadata as TimeSeriesMetadata,
             data: sortedData,
             environment,

--- a/src/components/time-series/time-series-cache.service.ts
+++ b/src/components/time-series/time-series-cache.service.ts
@@ -13,6 +13,26 @@ import type {
 
 export const TIME_SERIES_CACHE_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
 
+function getStartOfUtcDay(date: Date): Date {
+    return new Date(
+        Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+    )
+}
+
+function getEndOfUtcDay(date: Date): Date {
+    return new Date(
+        Date.UTC(
+            date.getUTCFullYear(),
+            date.getUTCMonth(),
+            date.getUTCDate(),
+            23,
+            59,
+            59,
+            999,
+        ),
+    )
+}
+
 export class TimeSeriesCacheService {
     getCacheKeyForVariable(
         variableEntryId: string,
@@ -25,14 +45,16 @@ export class TimeSeriesCacheService {
 
         const normalizedCoordinates = location
             .split(',')
-            .map(coord => Number(coord).toFixed(2))
+            .map((coord) => Number(coord).toFixed(2))
         const normalizedLocation = normalizedCoordinates.join(',%20')
         const normalizedEnvironment = environment ?? 'prod'
 
         return `${variableEntryId}_${normalizedLocation}_${normalizedEnvironment}`
     }
 
-    async getValidCacheEntry(cacheKey: string): Promise<VariableDbEntry | undefined> {
+    async getValidCacheEntry(
+        cacheKey: string,
+    ): Promise<VariableDbEntry | undefined> {
         if (!cacheKey) {
             return undefined
         }
@@ -72,16 +94,28 @@ export class TimeSeriesCacheService {
             return [{ start, end }]
         }
 
-        const existingStartDate = new Date(existingData.startDate)
-        const existingEndDate = new Date(existingData.endDate)
+        const requestedStart = getStartOfUtcDay(start)
+        const requestedEnd = getEndOfUtcDay(end)
+        const existingStartDate = getStartOfUtcDay(
+            new Date(existingData.startDate),
+        )
+        const existingEndDate = getEndOfUtcDay(new Date(existingData.endDate))
         const gaps: Array<{ start: Date; end: Date }> = []
 
-        if (start < existingStartDate) {
-            gaps.push({ start, end: existingStartDate })
+        if (requestedStart < existingStartDate) {
+            const leadingGapEnd = new Date(existingStartDate.getTime() - 1)
+
+            if (requestedStart <= leadingGapEnd) {
+                gaps.push({ start: requestedStart, end: leadingGapEnd })
+            }
         }
 
-        if (end > existingEndDate) {
-            gaps.push({ start: existingEndDate, end })
+        if (requestedEnd > existingEndDate) {
+            const trailingGapStart = new Date(existingEndDate.getTime() + 1)
+
+            if (trailingGapStart <= requestedEnd) {
+                gaps.push({ start: trailingGapStart, end: requestedEnd })
+            }
         }
 
         return gaps
@@ -98,11 +132,15 @@ export class TimeSeriesCacheService {
         return Array.from(seen.values())
     }
 
-    getDataInRange(data: TimeSeriesData, startDate: Date, endDate: Date): TimeSeriesData {
+    getDataInRange(
+        data: TimeSeriesData,
+        startDate: Date,
+        endDate: Date,
+    ): TimeSeriesData {
         return {
             ...data,
             data: data.data
-                .filter(row => {
+                .filter((row) => {
                     const timestamp = new Date(row.timestamp)
                     return timestamp >= startDate && timestamp <= endDate
                 })
@@ -127,41 +165,68 @@ export class TimeSeriesCacheService {
         /** The originally-requested end date. Same rationale as requestedStartDate. */
         requestedEndDate?: Date
     }): Promise<void> {
-        const { cacheKey, variableEntryId, environment, metadata, data,
-                requestedStartDate, requestedEndDate } = options
+        const {
+            cacheKey,
+            variableEntryId,
+            environment,
+            metadata,
+            data,
+            requestedStartDate,
+            requestedEndDate,
+        } = options
 
         if (!cacheKey) {
             return
         }
 
         const sortedData = [...data].sort(
-            (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+            (a, b) =>
+                new Date(a.timestamp).getTime() -
+                new Date(b.timestamp).getTime(),
         )
 
         // Use the requested range as the stored range when it extends beyond the actual data.
         // This prevents a cache-miss loop when the dataset simply has no data at the edges
         // (e.g. requesting Jan 1 but the first available data point is Jan 15).
-        const storedStart = requestedStartDate && sortedData.length > 0
-            ? new Date(Math.min(requestedStartDate.getTime(), new Date(sortedData[0].timestamp).getTime())).toISOString()
-            : sortedData[0]?.timestamp
-        const storedEnd = requestedEndDate && sortedData.length > 0
-            ? new Date(Math.max(requestedEndDate.getTime(), new Date(sortedData[sortedData.length - 1].timestamp).getTime())).toISOString()
-            : sortedData[sortedData.length - 1]?.timestamp
+        const storedStart =
+            requestedStartDate && sortedData.length > 0
+                ? new Date(
+                      Math.min(
+                          requestedStartDate.getTime(),
+                          new Date(sortedData[0].timestamp).getTime(),
+                      ),
+                  ).toISOString()
+                : sortedData[0]?.timestamp
+        const storedEnd =
+            requestedEndDate && sortedData.length > 0
+                ? new Date(
+                      Math.max(
+                          requestedEndDate.getTime(),
+                          new Date(
+                              sortedData[sortedData.length - 1].timestamp,
+                          ).getTime(),
+                      ),
+                  ).toISOString()
+                : sortedData[sortedData.length - 1]?.timestamp
 
         if (!storedStart || !storedEnd) {
             return
         }
 
-        await storeDataByKey<VariableDbEntry>(IndexedDbStores.TIME_SERIES, cacheKey, {
-            variableEntryId,
-            key: cacheKey,
-            startDate: storedStart,
-            endDate: storedEnd,
-            metadata: metadata as TimeSeriesMetadata,
-            data: sortedData,
-            environment,
-            cachedAt: Date.now(),
-        })
+        await storeDataByKey<VariableDbEntry>(
+            IndexedDbStores.TIME_SERIES,
+            cacheKey,
+            {
+                variableEntryId,
+                key: cacheKey,
+                startDate: storedStart,
+                endDate: storedEnd,
+                metadata: metadata as TimeSeriesMetadata,
+                data: sortedData,
+                environment,
+                cachedAt: Date.now(),
+            },
+        )
     }
 }
 

--- a/src/components/time-series/time-series.component.ts
+++ b/src/components/time-series/time-series.component.ts
@@ -67,6 +67,8 @@ const variableEntryIdsConverter = {
  * @event terra-date-range-change - Emitted whenever the date range is modified
  * @event terra-time-series-data-change - Emitted whenever time series data has been fetched from Giovanni
  * @event terra-harmony-job-status-update - Emitted whenever the status of a Harmony job is updated
+ * @event terra-time-series-loading-change - Emitted whenever loading starts or ends
+ * @event terra-time-series-chunk-progress-change - Emitted whenever chunked Harmony requests advance
  */
 export default class TerraTimeSeries extends QueryClientMixin(TerraElement) {
     static styles: CSSResultGroup = [componentStyles, styles]
@@ -143,7 +145,7 @@ export default class TerraTimeSeries extends QueryClientMixin(TerraElement) {
 
     @property({ type: Boolean, attribute: 'show-help' }) showHelp: boolean =
         true
-        
+
     /**
      * if you include an application citation, it will be displayed in the citation panel alongside the dataset citation
      */
@@ -237,6 +239,14 @@ export default class TerraTimeSeries extends QueryClientMixin(TerraElement) {
     @state()
     estimatedDataPoints = 0
 
+    @state()
+    private chunkProgress?: {
+        currentChunk: number
+        totalChunks: number
+    }
+
+    #isLoading = false
+
     _authController = new AuthController(this)
 
     _fetchVariableTask = getFetchVariableTask(this)
@@ -248,12 +258,33 @@ export default class TerraTimeSeries extends QueryClientMixin(TerraElement) {
             'terra-time-series-error',
             this.#handleQuotaError as EventListener,
         )
+        this.addEventListener(
+            'terra-time-series-chunk-progress-change',
+            this.#handleChunkProgress as EventListener,
+        )
     }
 
     updated(changedProps: Map<string, unknown>) {
         super.updated(changedProps)
 
         const taskStatus = this.#timeSeriesController.task.status
+        const isLoading =
+            taskStatus === TaskStatus.PENDING ||
+            this._fetchVariableTask.status === TaskStatus.PENDING
+
+        if (isLoading !== this.#isLoading) {
+            this.#isLoading = isLoading
+
+            this.dispatchEvent(
+                new CustomEvent('terra-time-series-loading-change', {
+                    detail: {
+                        loading: isLoading,
+                    },
+                    bubbles: true,
+                    composed: true,
+                }),
+            )
+        }
 
         // Clear error when a new request starts
         if (taskStatus === TaskStatus.PENDING && this.timeSeriesError) {
@@ -287,6 +318,10 @@ export default class TerraTimeSeries extends QueryClientMixin(TerraElement) {
             'terra-time-series-error',
             this.#handleQuotaError as EventListener,
         )
+        this.removeEventListener(
+            'terra-time-series-chunk-progress-change',
+            this.#handleChunkProgress as EventListener,
+        )
     }
 
     #handleQuotaError = (event: CustomEvent) => {
@@ -303,6 +338,17 @@ export default class TerraTimeSeries extends QueryClientMixin(TerraElement) {
         if (status === 429) {
             this.quotaExceededOpen = true
         }
+    }
+
+    #handleChunkProgress = (
+        event: CustomEvent<{ currentChunk: number; totalChunks: number }>,
+    ) => {
+        const { currentChunk, totalChunks } = event.detail
+
+        this.chunkProgress =
+            currentChunk > 0 && totalChunks > 1
+                ? { currentChunk, totalChunks }
+                : undefined
     }
 
     #confirmDataPointWarning() {
@@ -504,13 +550,24 @@ export default class TerraTimeSeries extends QueryClientMixin(TerraElement) {
                 ${
                     this.#timeSeriesController.task.status ===
                     TaskStatus.PENDING
-                        ? html`<p>
+                        ? html`
+                          <p>
+                              ${
+                                  this.catalogVariables.length > 1
+                                      ? `Plotting ${this.catalogVariables.length} variables…`
+                                      : `Plotting ${this.catalogVariable?.dataFieldId}…`
+                              }
+                          </p>
                           ${
-                              this.catalogVariables.length > 1
-                                  ? `Plotting ${this.catalogVariables.length} variables…`
-                                  : `Plotting ${this.catalogVariable?.dataFieldId}…`
+                              this.chunkProgress
+                                  ? html`<p>
+                                        Fetching chunk
+                                        ${this.chunkProgress.currentChunk} of
+                                        ${this.chunkProgress.totalChunks}&hellip;
+                                    </p>`
+                                  : nothing
                           }
-                      </p>`
+                      `
                         : html`<p>Preparing plot&hellip;</p>`
                 }
 

--- a/src/components/time-series/time-series.controller.ts
+++ b/src/components/time-series/time-series.controller.ts
@@ -7,6 +7,7 @@ import type {
     TimeSeriesData,
     TimeSeriesDataRow,
     TimeSeriesMetadata,
+    VariableDbEntry,
 } from './time-series.types.js'
 import type TerraTimeSeries from './time-series.component.js'
 import { TimeInterval } from '../../types.js'
@@ -34,6 +35,7 @@ const HARMONY_LINK_PROXY_URL =
     'https://lpo4uv7f0h.execute-api.us-east-1.amazonaws.com/default/harmony-link-proxy'
 const HARMONY_STATUS_WAIT_INTERVAL_MS = 300
 const MAX_CONCEPT_ID_WAIT_MS = 10000
+const MAX_GAP_FILL_PASSES = 4
 
 export const plotlyDefaultData: Partial<PlotData> = {
     // holds the default Plotly configuration options.
@@ -67,6 +69,19 @@ export class TimeSeriesController {
     lastTaskValue: Partial<Data>[] | undefined
 
     metadata: TimeSeriesMetadata
+
+    #emitChunkProgress(currentChunk: number, totalChunks: number) {
+        this.host.dispatchEvent(
+            new CustomEvent('terra-time-series-chunk-progress-change', {
+                detail: {
+                    currentChunk,
+                    totalChunks,
+                },
+                bubbles: true,
+                composed: true,
+            }),
+        )
+    }
 
     constructor(
         host: ReactiveControllerHost & TerraTimeSeries & QueryClientHost,
@@ -417,53 +432,113 @@ export class TimeSeriesController {
             )
         }
 
-        // We have gaps, so we'll need to request new data
-        // We'll do this in chunks in case the number of data points exceeds the API-imposed limit
-        const detectedInterval = existingTerraData?.data
-            ? this.#detectTimeInterval(existingTerraData.data)
-            : null
-        const timeInterval =
-            detectedInterval ||
-            (catalogVariable.dataProductTimeInterval as TimeInterval) ||
-            TimeInterval.Daily
-
-        const allChunks: Array<{ start: Date; end: Date }> = []
-
-        for (const gap of dataGaps) {
-            const chunks = calculateDateChunks(timeInterval, gap.start, gap.end)
-            allChunks.push(...chunks)
-        }
-
-        // Request chunks in parallel
-        const chunkResults = await Promise.all(
-            allChunks.map(async (chunk) => {
-                const result = await this.#fetchTimeSeriesChunk(
-                    variableEntryId,
-                    chunk.start,
-                    chunk.end,
-                    signal,
-                    catalogVariable,
-                )
-
-                return result
-            }),
-        )
-
+        // We have gaps, so we'll need to request new data.
+        // Use iterative gap-fill passes so if an initial large request returns a
+        // truncated window, we continue fetching missing leading/trailing ranges.
         let allData: TimeSeriesDataRow[] = existingTerraData?.data || []
         let metadata: TimeSeriesMetadata = (existingTerraData?.metadata ||
             {}) as TimeSeriesMetadata
+        let pendingGaps = dataGaps
 
-        // Merge all the chunk results
-        for (const chunkResult of chunkResults) {
-            allData = [...allData, ...chunkResult.data]
-            metadata = {
-                ...metadata,
-                ...chunkResult.metadata,
-            } as TimeSeriesMetadata
+        for (
+            let pass = 0;
+            pass < MAX_GAP_FILL_PASSES && pendingGaps.length > 0;
+            pass++
+        ) {
+            const detectedInterval = allData.length
+                ? this.#detectTimeInterval(allData)
+                : existingTerraData?.data
+                  ? this.#detectTimeInterval(existingTerraData.data)
+                  : null
+            const timeInterval =
+                detectedInterval ||
+                (catalogVariable.dataProductTimeInterval as TimeInterval) ||
+                TimeInterval.Daily
+
+            const allChunks: Array<{ start: Date; end: Date }> = []
+            for (const gap of pendingGaps) {
+                const chunks = calculateDateChunks(
+                    timeInterval,
+                    gap.start,
+                    gap.end,
+                )
+                allChunks.push(...chunks)
+            }
+
+            const shouldReportChunkProgress = allChunks.length > 1
+            const previousDataLength = allData.length
+
+            try {
+                for (const [index, chunk] of allChunks.entries()) {
+                    if (shouldReportChunkProgress) {
+                        this.#emitChunkProgress(index + 1, allChunks.length)
+                    }
+
+                    const result = await this.#fetchTimeSeriesChunk(
+                        variableEntryId,
+                        chunk.start,
+                        chunk.end,
+                        signal,
+                        catalogVariable,
+                    )
+
+                    allData = [...allData, ...result.data]
+                    metadata = {
+                        ...metadata,
+                        ...result.metadata,
+                    } as TimeSeriesMetadata
+
+                    allData = this.#cacheService.deduplicateByTimestamp(allData)
+
+                    // Persist progressive chunk results so successful chunks are
+                    // retained even if a later chunk is cancelled or fails.
+                    if (this.host.cache) {
+                        await this.#cacheService.storeConsolidatedData({
+                            cacheKey,
+                            variableEntryId,
+                            environment: this.host.environment,
+                            metadata,
+                            data: allData,
+                        })
+                    }
+                }
+            } finally {
+                if (shouldReportChunkProgress) {
+                    this.#emitChunkProgress(0, 0)
+                }
+            }
+
+            // No progress means we've reached the available data limits.
+            if (allData.length === previousDataLength) {
+                break
+            }
+
+            const sortedData = [...allData].sort(
+                (a, b) =>
+                    new Date(a.timestamp).getTime() -
+                    new Date(b.timestamp).getTime(),
+            )
+
+            const synthesizedCoverage: VariableDbEntry | undefined =
+                sortedData.length > 0
+                    ? ({
+                          variableEntryId,
+                          key: cacheKey,
+                          startDate: sortedData[0].timestamp,
+                          endDate: sortedData[sortedData.length - 1].timestamp,
+                          cachedAt: Date.now(),
+                          metadata: metadata as TimeSeriesMetadata,
+                          data: sortedData,
+                          environment: this.host.environment,
+                      } as VariableDbEntry)
+                    : undefined
+
+            pendingGaps = this.#cacheService.calculateDataGaps(
+                startDate,
+                endDate,
+                synthesizedCoverage,
+            )
         }
-
-        // Deduplicate by timestamp to prevent duplicate entries
-        allData = this.#cacheService.deduplicateByTimestamp(allData)
 
         const consolidatedResult: TimeSeriesData = {
             metadata,

--- a/src/components/time-series/time-series.controller.ts
+++ b/src/components/time-series/time-series.controller.ts
@@ -470,7 +470,10 @@ export class TimeSeriesController {
             data: allData,
         }
 
-        // Save the consolidated data to IndexedDB (including fill values to avoid unnecessary API requests)
+        // Save the consolidated data to IndexedDB (including fill values to avoid unnecessary API requests).
+        // Pass the requested start/end so that the stored range covers the full requested window even
+        // if Harmony returned data starting after the requested start (e.g. no data before Jan 15).
+        // Without this, every future request for the same range would detect a gap and fire a new job.
         // Only when cache mode is enabled
         if (this.host.cache) {
             await this.#cacheService.storeConsolidatedData({
@@ -479,6 +482,8 @@ export class TimeSeriesController {
                 environment: this.host.environment,
                 metadata: consolidatedResult.metadata,
                 data: allData,
+                requestedStartDate: startDate,
+                requestedEndDate: endDate,
             })
         }
 

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -59,3 +59,5 @@ export type { TerraDateSelectionInvalidEvent } from './terra-date-selection-inva
 export type { TerraHarmonyJobStatusUpdateEvent } from './terra-harmony-job-status-update.js'
 export type { TerraHarmonyJobSelectEvent } from './terra-harmony-job-select.js'
 export type { TerraHarmonyJobDeleteEvent } from './terra-harmony-job-delete.js'
+export type { TerraTimeSeriesLoadingChangeEvent } from './terra-time-series-loading-change.js'
+export type { TerraTimeSeriesChunkProgressChangeEvent } from './terra-time-series-chunk-progress-change.js'

--- a/src/events/terra-time-series-chunk-progress-change.ts
+++ b/src/events/terra-time-series-chunk-progress-change.ts
@@ -1,0 +1,12 @@
+export interface TerraTimeSeriesChunkProgressChangeEvent extends CustomEvent {
+    detail: {
+        currentChunk: number
+        totalChunks: number
+    }
+}
+
+declare global {
+    interface GlobalEventHandlersEventMap {
+        'terra-time-series-chunk-progress-change': TerraTimeSeriesChunkProgressChangeEvent
+    }
+}

--- a/src/events/terra-time-series-loading-change.ts
+++ b/src/events/terra-time-series-loading-change.ts
@@ -1,0 +1,11 @@
+export interface TerraTimeSeriesLoadingChangeEvent extends CustomEvent {
+    detail: {
+        loading: boolean
+    }
+}
+
+declare global {
+    interface GlobalEventHandlersEventMap {
+        'terra-time-series-loading-change': TerraTimeSeriesLoadingChangeEvent
+    }
+}

--- a/src/lib/api.client.ts
+++ b/src/lib/api.client.ts
@@ -23,7 +23,12 @@ async function request<T>(
         const res = await fetch(url, {
             method,
             headers,
-            body: body ? JSON.stringify(body) : undefined,
+            body:
+                body instanceof FormData
+                    ? body
+                    : body
+                      ? JSON.stringify(body)
+                      : undefined,
             signal,
         })
 

--- a/src/lib/dataset.test.ts
+++ b/src/lib/dataset.test.ts
@@ -1,4 +1,4 @@
-import { calculateDataPoints } from './dataset.js'
+import { calculateDataPoints, calculateDateChunks } from './dataset.js'
 import { expect } from '@open-wc/testing'
 import { TimeInterval } from '../types.js'
 
@@ -109,7 +109,80 @@ describe('calculateDataPoints', () => {
 
     it('should throw an error for unsupported time interval', () => {
         expect(() => {
-            calculateDataPoints('unsupported' as TimeInterval, new Date(), new Date())
+            calculateDataPoints(
+                'unsupported' as TimeInterval,
+                new Date(),
+                new Date(),
+            )
         }).to.throw('Unsupported time interval')
+    })
+})
+
+describe('calculateDateChunks', () => {
+    it('returns a single chunk when range is within the API data point limit', () => {
+        const start = new Date('2024-01-01T00:00:00Z')
+        const end = new Date('2024-01-15T00:00:00Z')
+
+        const chunks = calculateDateChunks(TimeInterval.Hourly, start, end)
+
+        expect(chunks).to.have.length(1)
+        expect(chunks[0].start.toISOString()).to.equal(start.toISOString())
+        expect(chunks[0].end.toISOString()).to.equal(end.toISOString())
+    })
+
+    it('splits into multiple chunks when range exceeds the API data point limit', () => {
+        const start = new Date('1997-01-01T00:00:00Z')
+        const end = new Date('2026-01-01T00:00:00Z')
+
+        const chunks = calculateDateChunks(TimeInterval.Hourly, start, end)
+
+        expect(chunks.length).to.be.greaterThan(1)
+        expect(chunks[0].start.toISOString()).to.equal(start.toISOString())
+        expect(chunks[chunks.length - 1].end.toISOString()).to.equal(
+            end.toISOString(),
+        )
+
+        for (let i = 0; i < chunks.length; i++) {
+            const chunk = chunks[i]
+            const points = calculateDataPoints(
+                TimeInterval.Hourly,
+                chunk.start,
+                chunk.end,
+            )
+
+            expect(points).to.be.at.most(200000)
+
+            if (i > 0) {
+                expect(chunk.start.getTime()).to.be.greaterThan(
+                    chunks[i - 1].end.getTime(),
+                )
+            }
+        }
+    })
+
+    it('does not create overlapping or near-zero tail chunks for long hourly ranges', () => {
+        const start = new Date('1997-01-01T00:00:00.000Z')
+        const end = new Date('2026-01-01T00:00:00.000Z')
+
+        const chunks = calculateDateChunks(TimeInterval.Hourly, start, end)
+
+        expect(chunks.length).to.be.greaterThan(1)
+
+        for (let i = 1; i < chunks.length; i++) {
+            const previousChunk = chunks[i - 1]
+            const currentChunk = chunks[i]
+
+            // Each chunk should advance by one full interval, never re-requesting
+            // the prior chunk's end timestamp.
+            expect(currentChunk.start.getTime()).to.equal(
+                previousChunk.end.getTime() + 60 * 60 * 1000,
+            )
+        }
+
+        const lastChunk = chunks[chunks.length - 1]
+        const lastChunkDurationMs =
+            lastChunk.end.getTime() - lastChunk.start.getTime()
+
+        expect(lastChunkDurationMs).to.be.greaterThan(0)
     })
 })

--- a/src/lib/dataset.ts
+++ b/src/lib/dataset.ts
@@ -4,6 +4,27 @@ const MAX_DATAPOINTS_PER_REQUEST = 200000 // this is a limit imposed by the Clou
 const MILLIS_IN_HOUR = 1000 * 60 * 60
 const MILLIS_IN_DAY = MILLIS_IN_HOUR * 24
 
+function getIntervalMs(timeInterval: TimeInterval): number {
+    switch (timeInterval) {
+        case TimeInterval.HalfHourly:
+            return MILLIS_IN_HOUR / 2
+        case TimeInterval.Hourly:
+            return MILLIS_IN_HOUR
+        case TimeInterval.ThreeHourly:
+            return MILLIS_IN_HOUR * 3
+        case TimeInterval.EightDaily:
+            return MILLIS_IN_DAY * 8
+        case TimeInterval.Daily:
+            return MILLIS_IN_DAY
+        case TimeInterval.Weekly:
+            return MILLIS_IN_DAY * 7
+        case TimeInterval.Monthly:
+            return MILLIS_IN_DAY * 30
+        default:
+            throw new Error(`Unsupported time interval: ${timeInterval}`)
+    }
+}
+
 export function calculateDataPoints(
     timeInterval: TimeInterval,
     startDate: Date,
@@ -58,49 +79,35 @@ export function calculateDateChunks(
         return [{ start: startDate, end: endDate }]
     }
 
-    // We are over the max datapoints so we'll need to chunk the data into multiple requests
+    // Build chunks using the native interval step to avoid overlapping boundaries
+    // and near-zero-length tail chunks due to millisecond rounding drift.
     const chunks: Array<{ start: Date; end: Date }> = []
-    const totalDurationMs = endDate.getTime() - startDate.getTime()
+    const intervalMs = getIntervalMs(timeInterval)
+    const maxChunkSpanMs = intervalMs * (MAX_DATAPOINTS_PER_REQUEST - 1)
 
-    // Calculate roughly how many chunks we'll need
-    const numChunks = Math.ceil(totalDataPoints / MAX_DATAPOINTS_PER_REQUEST)
+    let chunkStartMs = startDate.getTime()
+    const endMs = endDate.getTime()
 
-    // Calculate approximate chunk size in milliseconds
-    const chunkSizeMs = Math.floor(totalDurationMs / numChunks)
-
-    // Create each chunk
-    let chunkStart = new Date(startDate)
-    let remainingDuration = totalDurationMs
-
-    while (remainingDuration > 0) {
-        let potentialChunkEnd = new Date(chunkStart.getTime() + chunkSizeMs)
-
-        if (potentialChunkEnd > endDate) {
-            // Chunk end date is past the overall end date, use the overall end date
-            potentialChunkEnd = endDate
-        }
-
-        // Verify this chunk won't exceed the data point limit
-        const chunkDataPoints = calculateDataPoints(
-            timeInterval,
-            chunkStart,
-            potentialChunkEnd,
-        )
-
-        if (chunkDataPoints > MAX_DATAPOINTS_PER_REQUEST) {
-            // Chunk is too large, need to adjust the end date to fit within the restrictions
-            const maxDurationMs =
-                (chunkSizeMs * MAX_DATAPOINTS_PER_REQUEST) / chunkDataPoints
-            potentialChunkEnd = new Date(chunkStart.getTime() + maxDurationMs)
-        }
+    while (chunkStartMs <= endMs) {
+        const chunkEndMs = Math.min(chunkStartMs + maxChunkSpanMs, endMs)
 
         chunks.push({
-            start: new Date(chunkStart),
-            end: new Date(potentialChunkEnd),
+            start: new Date(chunkStartMs),
+            end: new Date(chunkEndMs),
         })
 
-        remainingDuration = endDate.getTime() - potentialChunkEnd.getTime()
-        chunkStart = potentialChunkEnd
+        if (chunkEndMs >= endMs) {
+            break
+        }
+
+        const nextChunkStartMs = chunkEndMs + intervalMs
+
+        // Safety guard against invalid interval configuration.
+        if (nextChunkStartMs <= chunkStartMs) {
+            break
+        }
+
+        chunkStartMs = nextChunkStartMs
     }
 
     return chunks

--- a/src/lib/harmony/__tests__/harmony.request.test.ts
+++ b/src/lib/harmony/__tests__/harmony.request.test.ts
@@ -735,4 +735,138 @@ describe('HarmonyRequest', () => {
             expect(roundtrippedParams).to.equal(originalParams)
         })
     })
+
+    describe('hasShape', () => {
+        it('returns false when no shape is set', () => {
+            const request = new HarmonyRequest({
+                collectionConceptId: COLLECTION_CONCEPT_ID,
+                location: BBOX,
+            })
+            expect(request.hasShape).to.equal(false)
+        })
+
+        it('returns true when a shape is set via constructor', () => {
+            const geoJson = {
+                type: 'FeatureCollection',
+                features: [],
+            }
+            const request = new HarmonyRequest({
+                collectionConceptId: COLLECTION_CONCEPT_ID,
+                shape: geoJson,
+            })
+            expect(request.hasShape).to.equal(true)
+        })
+
+        it('returns true when a shape is set via the shape() builder method', () => {
+            const geoJson = { type: 'FeatureCollection', features: [] }
+            const request = new HarmonyRequest()
+                .collection(COLLECTION_CONCEPT_ID)
+                .shape(geoJson)
+            expect(request.hasShape).to.equal(true)
+        })
+    })
+
+    describe('buildFormData', () => {
+        const SHAPE_GEOJSON = {
+            type: 'FeatureCollection',
+            features: [
+                {
+                    type: 'Feature',
+                    geometry: {
+                        type: 'Polygon',
+                        coordinates: [
+                            [
+                                [62.23, 5.29],
+                                [94.57, 5.29],
+                                [94.57, 37.49],
+                                [62.23, 37.49],
+                                [62.23, 5.29],
+                            ],
+                        ],
+                    },
+                    properties: null,
+                },
+            ],
+        }
+
+        it('returns a FormData instance', () => {
+            const request = new HarmonyRequest({
+                collectionConceptId: COLLECTION_CONCEPT_ID,
+                shape: SHAPE_GEOJSON,
+                format: 'application/x-netcdf4',
+            })
+            const formData = request.buildFormData()
+            expect(formData).to.be.instanceOf(FormData)
+        })
+
+        it('includes the shapefile field as a Blob', () => {
+            const request = new HarmonyRequest({
+                collectionConceptId: COLLECTION_CONCEPT_ID,
+                shape: SHAPE_GEOJSON,
+            })
+            const formData = request.buildFormData()
+            const shapefile = formData.get('shapefile')
+            expect(shapefile).to.be.instanceOf(Blob)
+        })
+
+        it('the shapefile blob contains valid GeoJSON', async () => {
+            const request = new HarmonyRequest({
+                collectionConceptId: COLLECTION_CONCEPT_ID,
+                shape: SHAPE_GEOJSON,
+            })
+            const formData = request.buildFormData()
+            const blob = formData.get('shapefile') as Blob
+            const text = await blob.text()
+            const parsed = JSON.parse(text)
+            expect(parsed.type).to.equal('FeatureCollection')
+        })
+
+        it('includes format as a form field when set', () => {
+            const request = new HarmonyRequest({
+                collectionConceptId: COLLECTION_CONCEPT_ID,
+                shape: SHAPE_GEOJSON,
+                format: 'application/x-netcdf4',
+            })
+            const formData = request.buildFormData()
+            expect(formData.get('format')).to.equal('application/x-netcdf4')
+        })
+
+        it('includes variable as a form field when set', () => {
+            const request = new HarmonyRequest({
+                collectionConceptId: COLLECTION_CONCEPT_ID,
+                shape: SHAPE_GEOJSON,
+                variables: [VARIABLE_ENTRY_ID],
+            })
+            const formData = request.buildFormData()
+            expect(formData.get('variable')).to.equal(VARIABLE_ENTRY_ID)
+        })
+
+        it('includes time subset as a form field when dates are set', () => {
+            const request = new HarmonyRequest({
+                collectionConceptId: COLLECTION_CONCEPT_ID,
+                shape: SHAPE_GEOJSON,
+                startDate: START_DATE,
+                endDate: END_DATE,
+            })
+            const formData = request.buildFormData()
+            const subsets = formData.getAll('subset')
+            const timeSubset = subsets.find((s) =>
+                (s as string).startsWith('time('),
+            )
+            expect(timeSubset).to.exist
+        })
+
+        it('does not include spatial lat/lon subsets (shape replaces spatial)', () => {
+            const request = new HarmonyRequest({
+                collectionConceptId: COLLECTION_CONCEPT_ID,
+                shape: SHAPE_GEOJSON,
+            })
+            const formData = request.buildFormData()
+            const subsets = formData.getAll('subset') as string[]
+            const hasSpatialSubset = subsets.some(
+                (s) => s.startsWith('lat(') || s.startsWith('lon('),
+            )
+            expect(hasSpatialSubset).to.equal(false)
+        })
+    })
 })

--- a/src/lib/harmony/harmony.request.ts
+++ b/src/lib/harmony/harmony.request.ts
@@ -134,6 +134,7 @@ export class HarmonyRequest {
             average,
             anonymous,
             dimensions,
+            skipPreview,
         } = this.#options
 
         if (location instanceof LatLng) {
@@ -149,7 +150,6 @@ export class HarmonyRequest {
             )
         }
 
-        // TODO: implement polygon
         // TODO: implement circle
 
         if (startDate) {
@@ -184,6 +184,12 @@ export class HarmonyRequest {
 
         if (anonymous) {
             params.append('maxResults', '10')
+        }
+
+        if (typeof skipPreview === 'boolean' && !skipPreview) {
+            params.append('skipPreview', 'false')
+        } else {
+            params.append('skipPreview', 'true')
         }
 
         return params.toString()

--- a/src/lib/harmony/harmony.request.ts
+++ b/src/lib/harmony/harmony.request.ts
@@ -4,6 +4,7 @@ import { LatLng } from '../../components/map/models/LatLng.js'
 import { LatLngBounds } from '../../components/map/models/LatLngBounds.js'
 import { BadRequestException } from '../../exceptions/http.exception.js'
 import type { Variable } from '../../components/browse-variables/browse-variables.types.js'
+import { simplifyToPointLimit } from '../../utilities/harmony.js'
 
 export type HarmonyRequestOptions = {
     environment?: Environments
@@ -12,6 +13,8 @@ export type HarmonyRequestOptions = {
     /* supplying variables is optional, will append &variable=VARIABLE to the URL */
     variables?: Array<string>
     location: LatLng | LatLngBounds
+    /** GeoJSON object for shape/polygon subsetting via multipart POST */
+    shape?: object
     startDate?: string
     endDate?: string
     format?: string
@@ -55,6 +58,40 @@ export class HarmonyRequest {
 
     get requestUrl() {
         return `${this.baseUrl}?${this.params}`
+    }
+
+    get hasShape() {
+        return !!this.#options.shape
+    }
+
+    /**
+     * Builds a multipart FormData body for shape (polygon) subsetting.
+     * All request params are appended as form fields (no query string).
+     * The GeoJSON shape is appended as a `shapefile` file field.
+     * Per HARMONY-290, Harmony cannot accept both files and query params simultaneously.
+     */
+    buildFormData(): FormData {
+        const formData = new FormData()
+
+        const searchParams = new URLSearchParams(this.params)
+        searchParams.forEach((value, key) => {
+            formData.append(key, value)
+        })
+
+        const geoJson = this.#options.shape
+        if (!geoJson) {
+            throw new BadRequestException({
+                message: 'shape is required to build form data',
+            })
+        }
+        // Simplify the GeoJSON shape to ensure it has <= 5000 vertices, as Harmony rejects requests with more than 5000 vertices in a shape polygon
+        const simplifiedGeoJson = simplifyToPointLimit(geoJson, 5000)
+        const blob = new Blob([JSON.stringify(simplifiedGeoJson)], {
+            type: 'application/geo+json',
+        })
+        formData.append('shapefile', blob, 'shape.geojson')
+
+        return formData
     }
 
     get baseUrl() {
@@ -199,6 +236,10 @@ export class HarmonyRequest {
 
     location(location: HarmonyRequestOptions['location']) {
         return this.set({ location })
+    }
+
+    shape(shape: object) {
+        return this.set({ shape })
     }
 
     dateRange(startDate: string, endDate: string) {

--- a/src/terra_ui_components/base.py
+++ b/src/terra_ui_components/base.py
@@ -16,12 +16,12 @@ class TerraBaseWidget(anywidget.AnyWidget):
         return f"""
         const terraStyles = document.createElement('link')
         terraStyles.rel = 'stylesheet'
-        terraStyles.href = 'https://cdn.jsdelivr.net/npm/@nasa-terra/components@0.0.191/cdn/themes/horizon.css'
+        terraStyles.href = 'https://cdn.jsdelivr.net/npm/@nasa-terra/components@0.0.192/cdn/themes/horizon.css'
         //terraStyles.href = "http://localhost:4000/dist/themes/horizon.css"
         document.head.appendChild(terraStyles)
 
         const terraAutoloader = document.createElement('script')
-        terraAutoloader.src = "https://cdn.jsdelivr.net/npm/@nasa-terra/components@0.0.191/cdn/terra-ui-components-autoloader.js"
+        terraAutoloader.src = "https://cdn.jsdelivr.net/npm/@nasa-terra/components@0.0.192/cdn/terra-ui-components-autoloader.js"
         //terraAutoloader.src = "http://localhost:4000/dist/terra-ui-components-autoloader.js"
         terraAutoloader.type = 'module'
         document.head.appendChild(terraAutoloader)

--- a/src/terra_ui_components/base.py
+++ b/src/terra_ui_components/base.py
@@ -16,12 +16,12 @@ class TerraBaseWidget(anywidget.AnyWidget):
         return f"""
         const terraStyles = document.createElement('link')
         terraStyles.rel = 'stylesheet'
-        terraStyles.href = 'https://cdn.jsdelivr.net/npm/@nasa-terra/components@0.0.193/cdn/themes/horizon.css'
+        terraStyles.href = 'https://cdn.jsdelivr.net/npm/@nasa-terra/components@0.0.194/cdn/themes/horizon.css'
         //terraStyles.href = "http://localhost:4000/dist/themes/horizon.css"
         document.head.appendChild(terraStyles)
 
         const terraAutoloader = document.createElement('script')
-        terraAutoloader.src = "https://cdn.jsdelivr.net/npm/@nasa-terra/components@0.0.193/cdn/terra-ui-components-autoloader.js"
+        terraAutoloader.src = "https://cdn.jsdelivr.net/npm/@nasa-terra/components@0.0.194/cdn/terra-ui-components-autoloader.js"
         //terraAutoloader.src = "http://localhost:4000/dist/terra-ui-components-autoloader.js"
         terraAutoloader.type = 'module'
         document.head.appendChild(terraAutoloader)

--- a/src/terra_ui_components/base.py
+++ b/src/terra_ui_components/base.py
@@ -16,12 +16,12 @@ class TerraBaseWidget(anywidget.AnyWidget):
         return f"""
         const terraStyles = document.createElement('link')
         terraStyles.rel = 'stylesheet'
-        terraStyles.href = 'https://cdn.jsdelivr.net/npm/@nasa-terra/components@0.0.192/cdn/themes/horizon.css'
+        terraStyles.href = 'https://cdn.jsdelivr.net/npm/@nasa-terra/components@0.0.193/cdn/themes/horizon.css'
         //terraStyles.href = "http://localhost:4000/dist/themes/horizon.css"
         document.head.appendChild(terraStyles)
 
         const terraAutoloader = document.createElement('script')
-        terraAutoloader.src = "https://cdn.jsdelivr.net/npm/@nasa-terra/components@0.0.192/cdn/terra-ui-components-autoloader.js"
+        terraAutoloader.src = "https://cdn.jsdelivr.net/npm/@nasa-terra/components@0.0.193/cdn/terra-ui-components-autoloader.js"
         //terraAutoloader.src = "http://localhost:4000/dist/terra-ui-components-autoloader.js"
         terraAutoloader.type = 'module'
         document.head.appendChild(terraAutoloader)

--- a/src/terra_ui_components/data_subsetter/data_subsetter.py
+++ b/src/terra_ui_components/data_subsetter/data_subsetter.py
@@ -21,6 +21,8 @@ class TerraDataSubsetter(TerraBaseWidget):
          * model.get() pulls from the Jupyter notebooks state. We'll use the state to set the initial value for each property
          */
         component.collectionEntryId = model.get('collectionEntryId')
+        component.shortName = model.get('shortName')
+        component.version = model.get('version')
         component.showCollectionSearch = model.get('showCollectionSearch')
         component.jobId = model.get('jobId')
         component.bearerToken = model.get('bearerToken')
@@ -41,6 +43,12 @@ class TerraDataSubsetter(TerraBaseWidget):
          */
         model.on('change:collectionEntryId', () => {
             component.collectionEntryId = model.get('collectionEntryId')
+        })
+        model.on('change:shortName', () => {
+            component.shortName = model.get('shortName')
+        })
+        model.on('change:version', () => {
+            component.version = model.get('version')
         })
         model.on('change:showCollectionSearch', () => {
             component.showCollectionSearch = model.get('showCollectionSearch')
@@ -75,10 +83,15 @@ class TerraDataSubsetter(TerraBaseWidget):
     """
 
     # Component properties
-    # While we have properties in the component, we also need to tell Python about them as well. 
+    # While we have properties in the component, we also need to tell Python about them as well.
     # Again, you don't technically need all these. If Jupyter Notebooks don't need access to them, you can remove them from here
     collectionEntryId = traitlets.Unicode('').tag(sync=True)
+    shortName = traitlets.Unicode('').tag(sync=True)
+    version = traitlets.Unicode('').tag(sync=True)
     showCollectionSearch = traitlets.Unicode('').tag(sync=True)
+    showHistoryPanel = traitlets.Unicode('').tag(sync=True)
     jobId = traitlets.Unicode('').tag(sync=True)
     bearerToken = traitlets.Unicode('').tag(sync=True)
-    job = traitlets.Any(default_value={}).tag(sync=True)
+    features = traitlets.Unicode('').tag(sync=True)
+    dialog = traitlets.Unicode('').tag(sync=True)
+    isHistoryView = traitlets.Bool(False).tag(sync=True)

--- a/src/utilities/date.test.ts
+++ b/src/utilities/date.test.ts
@@ -1,0 +1,30 @@
+import { expect } from '@open-wc/testing'
+import { formatDate, isDateRangeContained } from './date.js'
+
+describe('date utilities', () => {
+    it('formats date-only strings in UTC (no timezone day shift)', () => {
+        const value = formatDate('2016-01-01T00:00:00.000Z')
+        expect(value).to.equal('2016-01-01')
+    })
+
+    it('formats time strings in UTC', () => {
+        const value = formatDate('2016-01-01T23:30:00.000Z', 'yyyy-MM-dd HH:mm')
+        expect(value).to.equal('2016-01-01 23:30')
+    })
+
+    it('checks date range containment by UTC day boundaries', () => {
+        const requestedStart = new Date('2016-01-01T00:00:00.000Z')
+        const requestedEnd = new Date('2016-05-06T23:59:59.999Z')
+        const existingStart = new Date('2016-01-01T12:00:00.000Z')
+        const existingEnd = new Date('2016-05-06T00:00:00.000Z')
+
+        expect(
+            isDateRangeContained(
+                requestedStart,
+                requestedEnd,
+                existingStart,
+                existingEnd,
+            ),
+        ).to.equal(true)
+    })
+})

--- a/src/utilities/date.ts
+++ b/src/utilities/date.ts
@@ -1,10 +1,12 @@
-import { isValid, format } from 'date-fns'
+import { isValid } from 'date-fns'
 
 type MaybeDate = string | number | Date
 
-export function isValidDate(date: any): boolean {
-    const parsedDate = Date.parse(date)
-    return !isNaN(parsedDate) && isValid(parsedDate)
+export function isValidDate(date: string | number | Date): boolean {
+    const parsedDate =
+        date instanceof Date ? date.getTime() : Date.parse(String(date))
+
+    return !Number.isNaN(parsedDate) && isValid(parsedDate)
 }
 
 export function getUTCDate(date: MaybeDate, endOfDay: boolean = false) {
@@ -27,6 +29,26 @@ export function getUTCDate(date: MaybeDate, endOfDay: boolean = false) {
     return utcDate
 }
 
+function pad2(value: number): string {
+    return String(value).padStart(2, '0')
+}
+
+function pad4(value: number): string {
+    return String(value).padStart(4, '0')
+}
+
+function formatUtcWithPattern(date: Date, pattern: string): string {
+    const replacements: Record<string, string> = {
+        yyyy: pad4(date.getUTCFullYear()),
+        MM: pad2(date.getUTCMonth() + 1),
+        dd: pad2(date.getUTCDate()),
+        HH: pad2(date.getUTCHours()),
+        mm: pad2(date.getUTCMinutes()),
+    }
+
+    return pattern.replace(/yyyy|MM|dd|HH|mm/g, (token) => replacements[token])
+}
+
 /**
  * formats a date using date-fns format patterns
  * See https://date-fns.org/v3.6.0/docs/format for available formatting options
@@ -46,7 +68,7 @@ export function formatDate(date: MaybeDate, formatString?: string) {
 
     // Default format if none provided
     const defaultFormat = 'yyyy-MM-dd'
-    return format(dateObj, formatString || defaultFormat)
+    return formatUtcWithPattern(dateObj, formatString || defaultFormat)
 }
 
 /**
@@ -57,36 +79,44 @@ export function isDateRangeContained(
     start1: Date,
     end1: Date,
     start2: Date,
-    end2: Date
+    end2: Date,
 ): boolean {
     const startOfDay1 = new Date(
-        start1.getFullYear(),
-        start1.getMonth(),
-        start1.getDate()
+        Date.UTC(
+            start1.getUTCFullYear(),
+            start1.getUTCMonth(),
+            start1.getUTCDate(),
+        ),
     )
     const startOfDay2 = new Date(
-        start2.getFullYear(),
-        start2.getMonth(),
-        start2.getDate()
+        Date.UTC(
+            start2.getUTCFullYear(),
+            start2.getUTCMonth(),
+            start2.getUTCDate(),
+        ),
     )
 
     const endOfDay1 = new Date(
-        end1.getFullYear(),
-        end1.getMonth(),
-        end1.getDate(),
-        23,
-        59,
-        59,
-        999
+        Date.UTC(
+            end1.getUTCFullYear(),
+            end1.getUTCMonth(),
+            end1.getUTCDate(),
+            23,
+            59,
+            59,
+            999,
+        ),
     )
     const endOfDay2 = new Date(
-        end2.getFullYear(),
-        end2.getMonth(),
-        end2.getDate(),
-        23,
-        59,
-        59,
-        999
+        Date.UTC(
+            end2.getUTCFullYear(),
+            end2.getUTCMonth(),
+            end2.getUTCDate(),
+            23,
+            59,
+            59,
+            999,
+        ),
     )
 
     return startOfDay1 >= startOfDay2 && endOfDay1 <= endOfDay2

--- a/src/utilities/harmony.ts
+++ b/src/utilities/harmony.ts
@@ -1,5 +1,7 @@
 import { html } from 'lit'
 import type { TemplateResult } from 'lit'
+import type { AllGeoJSON } from '@turf/helpers'
+import { simplify, coordAll } from '@turf/turf'
 import type { SubsetJobError } from '../apis/harmony.api.js'
 
 export interface HarmonyErrorDetails {
@@ -190,4 +192,72 @@ export function formatHarmonyErrorMessage(error: HarmonyError): TemplateResult {
             >contact us using the Earthdata Forum</a
         >
     `
+}
+
+/**
+ * Simplifies a GeoJSON object using binary search over the Douglas-Peucker
+ * tolerance to find the finest tolerance that brings the vertex count to
+ * at or below maxPoints. This maximises shape fidelity rather than
+ * just getting under the limit by the smallest possible margin.
+ *
+ * @param geoJson - Any valid GeoJSON object
+ * @param maxPoints - Maximum number of vertices allowed
+ * @returns Simplified GeoJSON, or the original if it was already under the limit
+ */
+export function simplifyToPointLimit(
+    geoJson: object,
+    maxPoints: number,
+): object {
+    const asAllGeoJson = geoJson as AllGeoJSON
+
+    if (coordAll(asAllGeoJson).length <= maxPoints) {
+        return geoJson
+    }
+
+    // Phase 1: find an upper-bound tolerance that actually gets us under maxPoints
+    // by doubling from a fine starting point until it works.
+    let high = 0.001
+    while (
+        coordAll(
+            simplify(asAllGeoJson, {
+                tolerance: high,
+                highQuality: false,
+                mutate: false,
+            }),
+        ).length > maxPoints
+    ) {
+        high *= 2
+        if (high >= 1) break
+    }
+
+    // Phase 2: binary-search in [0, high] for the finest (lowest) tolerance
+    // that still satisfies the limit, maximising retained detail.
+    let low = 0
+    let best = simplify(asAllGeoJson, {
+        tolerance: high,
+        highQuality: false,
+        mutate: false,
+    })
+
+    for (let i = 0; i < 24; i++) {
+        const mid = (low + high) / 2
+        const candidate = simplify(asAllGeoJson, {
+            tolerance: mid,
+            highQuality: false,
+            mutate: false,
+        })
+
+        if (coordAll(candidate).length <= maxPoints) {
+            best = candidate
+            high = mid // can try finer
+        } else {
+            low = mid // too fine, need coarser
+        }
+    }
+
+    console.log(
+        `Simplified GeoJSON from ${coordAll(asAllGeoJson).length} to ${coordAll(best).length} vertices`,
+    )
+
+    return best
 }


### PR DESCRIPTION
# Overview

## Linked issue

Closes https://bugs.earthdata.nasa.gov/browse/GUUI-3702

## What is the feature?

Adds shapefile/polygon spatial subsetting to `terra-data-subsetter`, plus several fixes that surfaced while building and testing it: timezone/12-hour support in `terra-date-picker`, correct time-series data-rods chunking/caching, surfaced Harmony job errors in the subsetter UI, and an anonymous-request bug fix.

## What is the solution?

- **Shapefile subsetting** (`0bb4efcc`): `terra-spatial-picker` now supports a shape selector and freehand polygon drawing on the map (`spatial-picker.component.ts`, `map.service.ts`, `map/type.ts`). `terra-data-subsetter` tracks the resulting GeoJSON (`shapeGeoJson`/`spatialLabel`) and passes it to the Harmony request via a new `.shape()` builder method (`harmony.request.ts`, `utilities/harmony.ts`).
- **Show subsetter errors** (`cf1b686c`): `#getData()` now catches Harmony job-creation failures and renders them in the UI (`harmonyRequestError` state), with a friendlier "no matching granules" message that links back to refining the search parameters. Also adds collection metadata (`collection-entry-id`, `collection-entry-title`) as Harmony job labels.
- **Anonymous requests fix** (`07c0c3e5`): corrects how unauthenticated Harmony requests are sent (`harmony.api.ts`, `harmony.request.ts`).
- **Datepicker timezone/12-hour support** (`256da806`): `terra-date-picker` gains `timezone` (IANA identifier) and `twelve-hour` attributes for display purposes only — emitted values remain UTC. Includes new docs and a full test suite (`date-picker.test.ts`).
- **Data rods chunking/caching fixes** (`c161f2a0`, `2da80cc8`): fixes gap-detection and cache range calculations in `time-series-cache.service.ts` (day-boundary alignment, storing the originally-requested range so edge-of-dataset requests don't loop), reworks chunked request handling in `time-series.controller.ts`/`time-series.component.ts`, and disables the date-range slider with a "Loading chunk X of Y…" indicator in `terra-data-rods` while a chunked request is in flight.
- **New events** (`77905656`): adds `terra-time-series-chunk-progress-change` and `terra-time-series-loading-change` events so consumers (like `terra-data-rods`) can track chunked-request progress.

## What areas of the application does this impact?

- `terra-data-subsetter` (shape/polygon spatial selection, error handling, job labels)
- `terra-spatial-picker` / `terra-map` (shape selector, polygon drawing)
- `terra-date-picker` (timezone, 12-hour format)
- `terra-data-rods` / `terra-time-series` (chunked request caching, progress UI, new events)
- Harmony API client/request builder (`src/apis/harmony.api.ts`, `src/lib/harmony/harmony.request.ts`)
- Python `data_subsetter` widget and docs

# Testing

## Reproduction steps

1. Open `terra-data-subsetter` for a collection that supports shape subsetting.
2. Draw a polygon or select a shape from the shape selector, fill in the remaining parameters, and click **Get Data** — confirm the job is created with the shape applied.
3. Trigger a request with no matching granules and confirm the error message with "expanding your search" link is shown, and clicking it returns to the refine-parameters view.
4. In `terra-date-picker`, set `enable-time`, `timezone="America/New_York"`, and `twelve-hour`, and confirm the input/time picker display in 12-hour local time while emitted values stay UTC.
5. In `terra-data-rods`, select a wide date range that requires multiple chunked requests and confirm the date-range slider disables with a "Loading chunk X of Y…" message, then re-enables when loading completes.

# Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] This change was discussed in a linked issue or JIRA ticket before I opened this PR
- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
